### PR TITLE
Adding back APA

### DIFF
--- a/Draft-2018-TTWG-Charter.html
+++ b/Draft-2018-TTWG-Charter.html
@@ -462,6 +462,11 @@
         <div>
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
+            <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures (APA) Working Group</a></dt>
+            <dd>
+                The mission of the Accessible Platform Architectures Working Group (APA WG) is to ensure W3C specifications
+                provide support for accessibility to people with disabilities.
+            </dd>
             <dt><a href="https://www.w3.org/Style/CSS/">CSS Working Group</a></dt>
             <dd>The work of the Working Group coordinates with this group on
               presentation and layout issues.</dd>


### PR DESCRIPTION
Given the importance of captioning in the accessibility story, it would be best to keep the explicite mention of the APA Working Group in the list of dependencies.
