### PR TITLE
Remove duplicate "should".

### DIFF
--- a/Draft-2018-TTWG-Charter.html
+++ b/Draft-2018-TTWG-Charter.html
@@ -181,7 +181,7 @@
                   The Web Video Text Tracks Format</a> produced by the <a href="https://www.w3.org/community/texttracks/">Web
                   Media Text Tracks Community Group</a>. Some may be deferred to
                 future versions. </li>
-              <li>Should address the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media
+              <li>Address the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media
                   Accessibility User Requirements</a>.</li>
             </ol>
           </li>


### PR DESCRIPTION
Since the list is introduced with "SHOULD", the second item shouldn't begin with a duplicate "Should", but should instead parallel the first.