### PR TITLE
Use template for horizontal reviews

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
           Interest Groups, and with the <a href="https://www.w3.org/2001/tag/"
           title="Technical Architecture Group">TAG</a>. Invitation for review must be issued during each
           major standards-track document transition, including <a href="https://www.w3.org/Consortium/Process/#RecsWD"
-          title="First Public Working Draft">FPWD</a> and at least 3 months before
+          title="First Public Working Draft">FPWD</a> and at least 3 months before first entering
           <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a>,
           and should be issued when major changes occur in a specification.</p>
 

--- a/index.html
+++ b/index.html
@@ -285,9 +285,17 @@
       <div>
         <h3 id="w3c-coordination">W3C Groups</h3>
 
-        <p>To promote interoperability with the overall web platform, and for all Recommendation-track documents, the
-        Working Group SHALL seek <a href="https://www.w3.org/Guide/Charter.html#horizontal-review">horizontal
-        review</a> with the W3C Horizontal Groups listed below.</p>
+
+
+        <p>For all specifications, this Working Group will seek <a
+          href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal review</a> for
+          accessibility, internationalization, performance, privacy, and security with the relevant Working and
+          Interest Groups, and with the <a href="https://www.w3.org/2001/tag/"
+          title="Technical Architecture Group">TAG</a>. Invitation for review must be issued during each
+          major standards-track document transition, including <a href="https://www.w3.org/Consortium/Process/#RecsWD"
+          title="First Public Working Draft">FPWD</a> and at least 3 months before
+          <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a>,
+          and should be issued when major changes occur in a specification.</p>
 
         <dl>
           <dt>


### PR DESCRIPTION
This addresses the comment in
 https://github.com/w3c/strategy/issues/177#issuecomment-497142640

Give the current set of issues we have with groups not doing proper horizontal reviews, I concur with @samuelweiler that the charter template wording is the proper one to use for now, and should be the one used for the AC review of the charter.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: Invalid URI "https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fcharter-timed-text%2F11dce8e6fdc7efdba16771094999b0db8fdabd9a%2Findex.html" :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 31, 2019, 12:00 PM UTC)_.

<details>
<summary>More</summary>



:link: [Related URL](https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fcharter-timed-text%2F11dce8e6fdc7efdba16771094999b0db8fdabd9a%2Findex.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/charter-timed-text%2352.)._
</details>
