### PR TITLE
Charter template for 2022

### DIFF
--- a/charter-2019.html
+++ b/charter-2019.html
@@ -1,0 +1,652 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <title>Timed Text Working Group Charter</title>
+  <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
+  <link rel="stylesheet" type="text/css" href="https://www.w3.org/Guide/pubrules-style.css">
+  <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css">
+  <style type="text/css">
+      ul#navbar {
+        font-size: small;
+      }
+
+
+      dt.spec {
+        font-weight: bold;
+      }
+
+      dt.spec new {
+        background: yellow;
+      }
+
+      ul.out-of-scope > li {
+        font-weight: bold;
+      }
+
+      ul.out-of-scope > li > ul > li{
+        font-weight: normal;
+      }
+
+      .issue {
+        background: cornsilk;
+        font-style: italic;
+      }
+
+      .todo {
+        color: #900;
+      }
+
+      footer {
+        font-size: small;
+      }
+
+    .note {
+    background-color: #FAFAD2;
+    }
+
+    .note::before {
+    content: "NOTE: ";
+    }
+
+  </style>
+</head>
+<body>
+  <header id="header">
+    <aside>
+      <ul id="navbar">
+        <li>
+          <a href="#scope">Scope</a>
+        </li>
+
+        <li>
+          <a href="#deliverables">Deliverables</a>
+        </li>
+
+        <li>
+          <a href="#success">Success Criteria</a>
+        </li>
+
+        <li>
+          <a href="#coordination">Coordination</a>
+        </li>
+
+        <li>
+          <a href="#participation">Participation</a>
+        </li>
+
+        <li>
+          <a href="#communication">Communication</a>
+        </li>
+
+        <li>
+          <a href="#decisions">Decision Policy</a>
+        </li>
+
+        <li>
+          <a href="#patentpolicy">Patent Policy</a>
+        </li>
+
+        <li>
+          <a href="#licensing">Licensing</a>
+        </li>
+
+        <li>
+          <a href="#about">About this Charter</a>
+        </li>
+      </ul>
+    </aside>
+
+    <p><a href="https://www.w3.org/"><img alt="W3C" src="https://www.w3.org/Icons/w3c_home" height="48" width="72"></a>
+    </p>
+  </header>
+
+  <main>
+    <h1 id="title">Timed Text Working Group Charter</h1>
+
+    <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/AudioVideo/TT/">Timed Text
+    Working Group</a> is to develop W3C Recommendations for the representation of timed text in media, including
+    developing and maintaining new versions of the <a href="https://www.w3.org/TR/ttml/">Timed Text Markup Language</a> (TTML) and <a href="https://www.w3.org/TR/webvtt/">WebVTT</a> (Web Video Text Tracks)
+    based on implementation experience and interoperability feedback, and the creation of semantic mappings between
+    those languages.</p>
+
+    <div class="noprint">
+      <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/34314/join">Join the Timed Text Working
+      Group</a>.<a href="https://www.w3.org/2004/01/pp-impl/#####/join"></a></p>
+    </div>
+
+    <section id="details">
+      <table class="summary-table">
+        <tbody>
+          <tr id="Duration">
+            <th>Start date</th>
+            <td>28 November 2019</td>
+          </tr>
+
+          <tr id="Duration">
+            <th>End date</th>
+            <td>31 December 2021</td>
+          </tr>
+
+          <tr>
+            <th>Charter extension</th>
+            <td>
+              See <a href="#history">Change History</a>.
+            </td>
+          </tr>
+
+          <tr>
+            <th>Chairs</th>
+            <td>Nigel Megitt (BBC),<br>
+              Gary Katsevman (Brightcove)</td>
+          </tr>
+
+          <tr>
+            <th>Team Contacts</th>
+            <td>
+              <a href="mailto:atsushi@w3.org">Atsushi Shimono</a> <i>(0.2 <abbr title=
+              "Full-Time Equivalent">FTE</abbr>)</i>
+            </td>
+          </tr>
+
+          <tr>
+            <th>Meeting Schedule</th>
+            <td><strong>Teleconferences:</strong>Usually once per week.<br>
+            <strong>Face-to-face:</strong> Usually no more than twice per year, including once during the W3C's annual
+            Technical Plenary week.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="scope" class="scope">
+      <h2>Scope</h2>
+
+      <p>This group is chartered to develop specifications for the representation of timed text in media.</p>
+
+      <p>Timed text means text synchronized with other timed media, e.g. audio and video (2D, 3D, 360º, AR and VR), and
+      includes captions, subtitles, described video (aka video/audio description), karaoke lyrics, etc.</p>
+
+      <p>These specifications are intended to be used across the workflow from authoring to end-user presentation, and for both prepared
+      and live applications.</p>
+
+      <section id="success">
+        <div>
+          <h3>Success Criteria</h3>
+
+          <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title=
+          "Proposed Recommendation">Proposed Recommendation</a>, each Recommendation-track Technical Report SHOULD have
+          <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent
+          implementations</a> of each feature defined in the Technical Report.</p>
+
+          <p>Each Recommendation-track Technical Report:</p>
+
+          <ul>
+            <li>SHOULD contain a section detailing all known security and privacy implications for implementers, Web
+            authors, and end users.</li>
+
+            <li>SHOULD have an associated testing plan, starting from the earliest drafts.</li>
+
+            <li>SHOULD contain a section on accessibility that describes the benefits and impacts, including ways that
+            features defined in the Technical Report can be used to address them, and recommendations for maximising
+            accessibility in implementations.</li>
+
+            <li>SHOULD address the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media Accessibility User
+            Requirements</a>
+            </li>
+
+            <li>SHOULD contain a section discussing interoperability with previous versions, if any, of the Technical
+            Report, and other relevant specifications.</li>
+          </ul>
+
+          <p>To promote interoperability, all normative changes made to Technical Reports SHOULD have associated
+          <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
+        </div>
+      </section>
+    </section>
+
+    <section id="deliverables">
+      <h2>Deliverables</h2>
+
+      <p>More detailed milestones and updated publication schedules are available on the <a href=
+      "https://www.w3.org/wiki/TimedText/Publications">group publication status page</a>.</p>
+
+      <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected
+      completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a
+      stable state.</p>
+
+      <div id="normative">
+        <h3>New Technical Reports</h3>
+
+        <p>The Working Group intends to develop the following Technical Reports:</p>
+
+        <dl>
+          <dt class="spec">
+            <a href="https://www.w3.org/TR/ttml3/">Timed Text Markup Language 3 (TTML3)</a>
+          </dt>
+
+          <dd>
+            <p>This specification defines a content type that represents timed text media for the purpose of
+            interchange among authoring, distribution and playback systems. Timed text is textual information that is
+            intrinsically or extrinsically associated with timing information.</p>
+          </dd>
+
+          <dt id="webvtt" class="spec">
+            <a href="https://www.w3.org/TR/webvtt1/">WebVTT: The Web Video Text Tracks Format</a>
+          </dt>
+
+          <dd>
+            <p>This specification defines WebVTT, the Web Video Text Tracks format. Its main use is for marking up
+            external text track resources in connection with the HTML &lt;track&gt; element. WebVTT files provide
+            captions or subtitles for video content, and also text video descriptions <a href=
+            "http://www.w3.org/TR/media-accessibility-reqs/">[MAUR]</a>, chapters for content navigation,
+            and more generally any form of metadata that is time-aligned with audio or video content.</p>
+          </dd>
+
+          <dt id="adpt" class="spec">TTML Profile for Audio Description</dt>
+
+          <dd>
+            <p>This specification defines a profile of [ <cite><a class="bibref" href=
+            "https://www.w3.org/TR/ttml2/">TTML2</a></cite> ] intended to support audio description script exchange
+            throughout the workflow including production of the script, rendering as voice by recording or text to
+            speech synthesis, and audio mixing.</p>
+          </dd>
+        </dl>
+
+        <p>The Working Group MAY develop additional Recommendation-track and non-Recommendation-track Technical
+        Reports.</p>
+      </div>
+
+      <div id="revisions">
+        <h3>Existing Technical Reports</h3>
+
+        <p>The Working Group MAY update its <a href="https://www.w3.org/wiki/TimedText/Publications">previously
+        published Technical Reports</a>.</p>
+      </div>
+
+      <div id="ig-other-deliverables">
+        <h3>Other deliverables</h3>
+
+        <p>The Working Group MAY create documents that are not Technical Reports, including:</p>
+
+        <ul>
+          <li>Use case and requirement documents</li>
+
+          <li>Test suite and implementation reports</li>
+
+          <li>Primer or Best Practice documents to support web developers</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="coordination">
+      <h2>Coordination</h2>
+
+      <div>
+        <h3 id="w3c-coordination">W3C Groups</h3>
+
+        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal review</a> for
+          accessibility, internationalization, performance, privacy, and security with the relevant Working and
+          Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
+          Invitation for review must be issued during each major standards-track document transition, including
+          <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.  The
+          Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
+          each specification.  The Working Group is advised to seek a review at least 3 months before first entering
+          <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
+          to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+
+        <dl>
+          <dt>
+            <a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures (APA) Working Group</a>
+          </dt>
+
+          <dd>The mission of the Accessible Platform Architectures Working Group (APA WG) is to ensure W3C
+          specifications provide support for accessibility to people with disabilities.</dd>
+
+          <dt>
+            <a href="https://www.w3.org/community/audio-description/">Audio Description Community Group</a>
+          </dt>
+
+          <dd>This group developed the first Community report for the Audio Description Profile of TTML2.</dd>
+
+          <dt>
+            <a href="https://www.w3.org/Style/CSS/">CSS Working Group</a>
+          </dt>
+
+          <dd>The work of the Working Group coordinates with this group on presentation and layout issues.</dd>
+
+          <dt>
+            <a href="https://www.w3.org/2011/webtv/">Media and Entertainment Interest Group</a>
+          </dt>
+
+          <dd>The Media and Entertainment Interest Group provides a forum for Web and TV technical discussions, review
+          existing work, as well as the relationship between services on the Web and TV services, and identifies
+          requirements and potential solutions to ensure that the Web will function well with TV.</dd>
+
+          <dt>
+            <a href="https://www.w3.org/community/texttracks/">Web Media Text Tracks Community Group</a>
+          </dt>
+
+          <dd>This group developed the first Community report for the WebVTT format and will continue to explore new
+          features.</dd>
+
+          <dt>
+            <a href="https://www.w3.org/community/immersive-web/">Immersive Web Community Group</a>
+          </dt>
+
+          <dd>This group is to help bring high-performance Virtual Reality and Augmented Reality to the open Web.</dd>
+
+          <dt>
+            <a href="https://www.w3.org/WebPlatform/WG/">Web Platform Working Group</a>
+          </dt>
+
+          <dd>The HTML specification is intended to provide a semantic-level markup language and associated
+          semantic-level scripting APIs for authoring accessible pages on the Web ranging from static documents to
+          dynamic applications. It includes media elements to present video, audio and video text tracks and their
+          associated APIs.</dd>
+
+          <dd>
+          </dd>
+
+          <dt>
+            <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>
+          </dt>
+
+          <dd>
+          </dd>
+        </dl>
+
+        <p>Invitation for review SHALL be issued during each major Recommendation-track document transition, including
+        <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>, and when
+        major changes occur in a specification, and SHOULD be issued at least 3 months before <a href=
+        "https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a>.</p>
+
+        <h3 id="external-coordination">External Organizations</h3>
+
+        <p>The Working Group SHOULD, whenever possible, seek interoperability with other timed text formats, API, and
+        applications.</p>
+
+        <p>As such, the Working Group SHOULD seek review with the following external organizations.</p>
+
+        <dl>
+          <dt>
+            <a href="https://www.iso.org/committee/45316.html">ISO/IEC JTC-1/SC-29 WG 11 Moving Picture Experts Group
+            (MPEG)</a>
+          </dt>
+
+          <dd>This group is developing standards for coded representation of digital audio and video, including
+          MPEG-4.</dd>
+
+          <dt>
+            <a href="https://www.smpte.org/">Society of Motion Picture and Television Engineers (SMPTE)</a>
+          </dt>
+
+          <dd>This organization was founded to advance theory and development in the motion imaging field. SMPTE
+          produced extensions to TTML1 that are part of SMPTE-TT.</dd>
+
+          <dt>
+            <a href="https://www.ebu.ch/home">European Broadcasting Union (EBU)</a>
+          </dt>
+
+          <dd>The EBU is an association of national broadcasting organizations, facilitating the exchange of
+          audiovisual content. The EBU has developed EBU-TT, an XML-based format for use in subtitling production and
+          exchange, and EBU-TT-D for use in subtitle distribution, both of which are constrained and extended variants
+          of TTML1.</dd>
+
+          <dt>
+            <a href="https://www.dvb.org/groups/TM">DVB Project: Technical Module (DVB-TM)</a>
+          </dt>
+
+          <dd>The DVB Project develops specifications for digital television systems, which are turned into standards
+          by international standards bodies such as ETSI or CENELEC. It provides a conduit to other relevant
+          standardisation activities including MPEG for the purpose of meeting the objectives of the DVB Project.</dd>
+
+          <dt>
+            <a href="https://www.atsc.org/">Advanced Television Systems Committee (ATSC)</a>
+          </dt>
+
+          <dd>ATSC develops standards for digital television and depends on external standards for digital closed
+          captioning.</dd>
+
+          <dt>
+            <a href="https://www.3gpp.org/specifications-groups/sa-plenary/sa4-codec">3GPP SA4</a>
+          </dt>
+
+          <dd>SA WG4 Codec deals with the specifications for speech, audio, video, and multimedia codecs, in both circuit-switched and packet-switched environments.</dd>
+        </dl>
+      </div>
+    </section>
+
+    <section class="participation">
+      <h2 id="participation">Participation</h2>
+
+      <p>To be successful, the Working Group is expected to have 6 or more active participants for its duration,
+      including representatives from the key implementors of this specification, and active Editors and Test Leads for
+      each specification. The Chairs and specification Editors are expected to contribute half of a working day per
+      week towards the Working Group. There is no minimum requirement for other Participants.</p>
+
+      <p>The Working Group encourages questions, comments and issues on its public mailing lists and document
+      repositories, as described in <a href="#communication">Communication</a>.</p>
+
+      <p>The Working Group also welcomes non-Members to contribute technical submissions for consideration upon their
+      agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.</p>
+    </section>
+
+    <section id="communication">
+      <h2>Communication</h2>
+
+      <p id="public">Technical discussions for this Working Group are conducted in <a href=
+      "https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from
+      teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue
+      tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts
+      and Editor's Drafts of specifications will be developed on a public repository, and MAY permit direct public
+      contribution requests. The meetings themselves are not open to public participation, however.</p>
+
+      <p>Information about the Working Group (including details about deliverables, issues, actions, status,
+      participants, and meetings) will be available from the <a href="https://www.w3.org/AudioVideo/TT/">Timed Text
+      Working Group home page</a>.</p>
+
+      <p>Most <a href="https://www.w3.org/AudioVideo/TT/">Timed Text Working Group</a> teleconferences will focus on
+      discussion of particular specifications, and will be conducted on an as-needed basis.</p>
+
+      <p>This Working Group primarily conducts its technical work on the public mailing list public-tt@w3.org (<a href=
+      "http://lists.w3.org/Archives/Public/public-tt/">archive</a>) or <a id="public-github" href=
+      "https://github.com/w3c/">GitHub issues</a>. The public is invited to review, discuss and contribute to this
+      work.</p>
+
+      <p>The Working Group MAY use a Member-confidential mailing list member-tt@w3.org (<a href=
+      "http://lists.w3.org/Archives/Member/member-tt/">archive</a>) for administrative purposes and, at the discretion
+      of the Chairs and members of the group, for member-only discussions in special cases when a participant requests
+      such a discussion.</p>
+    </section>
+
+    <section id="decisions">
+      <h2>Decision Policy</h2>
+
+      <p>This Working Group will seek to make decisions through consensus and due process, per the <a href=
+      "https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 3.3</a>). Typically, an editor
+      or other participant makes an initial proposal, which is then refined in discussion with members of the Working
+      Group and other reviewers, and consensus emerges with little formal voting being required.</p>
+
+      <p>However, if a decision is necessary for timely progress, but consensus is not achieved after careful
+      consideration of the range of views presented, the Chairs MAY call for a Working Group vote, and record a
+      decision along with any objections.</p>
+
+      <p>To afford asynchronous decisions and organizational deliberation, any resolution (including publication
+      decisions) taken in a face-to-face meeting or teleconference will be considered provisional. A call for consensus
+      (CfC) will be issued for all resolutions (for example, via email and/or web-based survey), with a response period
+      of 10 working days. If no objections are raised on the mailing list by the end of the response period, the
+      resolution will be considered to have consensus as a resolution of the Working Group.</p>
+
+      <p>All decisions made by the Working Group SHOULD be considered resolved unless and until new information becomes
+      available, or unless reopened at the discretion of the Chairs or the Director.</p>
+
+      <p>This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C
+      Process Document (Section 3.4, Votes)</a>, and includes no voting procedures beyond what the Process Document
+      requires.</p>
+    </section>
+
+    <section id="patentpolicy">
+      <h2>Patent Policy</h2>
+
+      <p>This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent
+      Policy</a> (Version of 5 February 2004 updated 1 August 2017). To promote the widest adoption of Web standards,
+      W3C seeks to issue Recommendations that can be implemented, according to this policy, on a Royalty-Free basis.
+      For more information about disclosure obligations for this group, please see the <a href=
+      "https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.</p>
+    </section>
+
+    <section id="licensing">
+      <h2>Licensing</h2>
+
+      <p>For each deliverable the Working Group MAY choose either the <a href=
+      "https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> or the <a href=
+      "https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a>.</p>
+    </section>
+
+    <section id="about">
+      <h2>About this Charter</h2>
+
+      <p>This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section
+      5.2</a> of the <a href="https://www.w3.org/Consortium/Process">Process Document</a>. In the event of a conflict
+      between this document or the provisions of any charter and the W3C Process, the W3C Process SHALL take
+      precedence.</p>
+
+      <section id="history">
+        <h3>Charter History</h3>
+
+        <p>The following table lists details of all changes from the initial charter, per the <a href=
+        "https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 5.2.3)</a>:</p>
+
+        <table class="history">
+          <tbody>
+            <tr>
+              <th>Charter Period</th>
+              <th>Start Date</th>
+              <th>End Date</th>
+              <th>Changes</th>
+            </tr>
+
+            <tr>
+              <th>
+                <a href="http://www.w3.org/2008/01/timed-text-wg">Initial Charter</a>
+              </th>
+              <td>2008-08-15</td>
+              <td>2010-06-30</td>
+              <td>Restarted the Working Group</td>
+            </tr>
+
+            <tr>
+              <th>
+                <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2011JanMar/0026.html">Charter
+                Extension</a>
+              </th>
+              <td>
+              </td>
+              <td>2011-03-31</td>
+              <td>none</td>
+            </tr>
+
+            <tr>
+              <th>
+                <a href="http://www.w3.org/2012/07/ttml-charter.html">Rechartered</a>
+              </th>
+              <td>2012-07-25</td>
+              <td>2014-01-31</td>
+              <td>TTML 1.0 2nd edition, TTML 1.1</td>
+            </tr>
+
+            <tr>
+              <th>
+                <a href="http://www.w3.org/2014/03/timed-text-charter.html">Rechartered</a>
+              </th>
+              <td>2014-03-27</td>
+              <td>2016-03-30</td>
+              <td>WebVTT 1.0, IMSC 1.0</td>
+            </tr>
+
+            <tr>
+              <th>
+                <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2016AprJun/0008.html">Charter
+                Extension</a>
+              </th>
+              <td>
+              </td>
+              <td>2016-05-31</td>
+              <td>none</td>
+            </tr>
+
+            <tr>
+              <th>
+                <a href="https://www.w3.org/2016/05/timed-text-charter.html">Rechartered</a>
+              </th>
+              <td>2016-05-19</td>
+              <td>2018-03-31</td>
+              <td>none</td>
+            </tr>
+
+            <tr>
+              <th>
+                <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2018AprJun/0004.html">Charter
+                Extension</a>
+              </th>
+              <td>
+              </td>
+              <td>2018-05-31</td>
+              <td>none</td>
+            </tr>
+
+            <tr>
+              <th>
+                <a href="https://www.w3.org/2018/05/timed-text-charter.html">Rechartered</a>
+              </th>
+              <td>2018-05-30</td>
+              <td>2020-05-31</td>
+              <td>none</td>
+            </tr>
+
+            <tr>
+              <th>
+                <a href="https://www.w3.org/2019/11/timed-text-wg-charter.html">Rechartered</a>
+              </th>
+              <td>2019-11-28</td>
+              <td>2021-12-31</td>
+              <td>TTML3, TTML Profile for Audio Description
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="change_log">
+        <h3>Change Log</h3>
+        <p>Note: those modifications were done after the charter was approved by the Director.</p>
+        <dl>
+          <dt>2020-03-26</dt>
+          <dd>Charter History table for this period has been updated with correct dates and changes.
+        </dl>
+      </section>
+
+    </section>
+  </main>
+
+  <hr>
+
+  <footer>
+    <address>
+      Atsushi Shimono, Team Contact.
+    </address>
+
+    <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©2019
+    <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a>® ( <a href=
+    "https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href=
+    "https://www.ercim.eu/"><abbr title=
+    "European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href=
+    "https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a> ), All Rights Reserved.
+    <abbr title="World Wide Web Consortium">W3C</abbr> <a href=
+    "https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href=
+    "https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href=
+    "https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -533,9 +533,6 @@
 
       <section id="licensing">
         <h2>Licensing</h2>
-        <p>This Working Group will use the <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> or <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
-
-        <p class="todo">Following line is the current text (2019 charter)</p>
         <p>For each deliverable the Working Group MAY choose either the <a href=
           "https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> or the <a href=
           "https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a>.</p>

--- a/index.html
+++ b/index.html
@@ -290,15 +290,9 @@
       <li>SHOULD contain a section discussing interoperability with previous versions, if any, of the Technical Report, and other relevant specifications.</li>
     </ul>
     <p>To promote interoperability, all normative changes made to Technical Reports SHOULD have associated <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
-
-<!-- need to consider of -->
-    <p><i class="todo">NEED TO SELECT AND CONSIDER OF FOLLOWING ITEMS IN THE TEMPLATE.</i></p>
-    <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
-	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
-	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
-		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
+	  <p>There should be testing plans for each specification, starting from the earliest drafts. To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
+    <p>Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
 		recommendations for maximising accessibility in implementations.</p>
-	  <p>WE HAVE?: <span class='todo'>Consider adopting a healthy testing policy, such as:</span> To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
 	  <p>DROP?: <span class='todo'>Consider adding this clause if the Group does not intend to move to REC:</span> All new features should be supported by at least two intents to implement before being incorporated in the specification.</p>
 <!-- END: need to consider of -->
 	</section>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 
-    <title><i class="todo">[name]</i> (Working|Interest) Group Charter</title>
+    <title>PROPOSED Timed Text Working Group Charter</title>
 
     <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
@@ -60,7 +60,6 @@
           <li><a href="#participation">Participation</a></li>
           <li><a href="#communication">Communication</a></li>
           <li><a href="#decisions">Decision Policy</a></li>
-          <i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i>
           <li><a href="#patentpolicy">Patent Policy</a></li>
           <li><a href="#patentpolicy">Patent Disclosures</a></li>
           <li><a href="#licensing">Licensing</a></li>
@@ -74,19 +73,23 @@
 
 
     <main>
-      <h1 id="title"><i class="todo">PROPOSED [name]</i> (Working|Interest) Group Charter</h1>
+      <h1 id="title">PROPOSED Timed Text Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href=""><i class="todo">[name]</i> (Working|Interest) Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/AudioVideo/TT/">Timed Text
+        Working Group</a> is to develop W3C Recommendations for the representation of timed text in media, including
+        developing and maintaining new versions of the <a href="https://www.w3.org/TR/ttml/">Timed Text Markup Language</a> (TTML) and <a href="https://www.w3.org/TR/webvtt/">WebVTT</a> (Web Video Text Tracks)
+        based on implementation experience and interoperability feedback, and the creation of semantic mappings between
+        those languages.</p>
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/groups/wg/[shortname]/join">Join the <i class="todo">[name]</i> (Working|Interest) Group.</a></p>
+        <p class="join"><a href="https://www.w3.org/groups/wg/timed-text/join">Join the Timed Text Working Group.</a></p>
       </div>
 
          <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
-      on <i class="todo"><a href="https://github.com/w3c/@@">GitHub</a>.
+      on <i class="todo"><a href="https://github.com/w3c/charter-timed-text/">GitHub</a>.
 
-    Feel free to raise <a href="https://github.com/w3c/@@/issues">issues</a></i>.
+    Feel free to raise <a href="https://github.com/w3c/charter-timed-text/issues">issues</a></i>.
           </p>
 
       <section id="details">
@@ -96,7 +99,7 @@
               Start date
             </th>
             <td>
-              <i class="todo">[dd monthname yyyy] (date of the "Call for Participation", when the charter is approved)</i>
+              <i class="todo">1 January 2022</i>
             </td>
           </tr>
           <tr id="CharterEnd">
@@ -104,7 +107,7 @@
               End date
             </th>
             <td>
-              <i class="todo">[dd monthname yyyy]</i> (Start date + 2 years)
+              <i class="todo">31 December 2023</i> (Start date + 2 years)
             </td>
           </tr>
           <tr>
@@ -112,7 +115,8 @@
               Chairs
             </th>
             <td>
-              <i class="todo">[chair name] (affiliation)</i>
+              Nigel Megitt (BBC),<br>
+              Gary Katsevman (Brightcove)
             </td>
           </tr>
           <tr>
@@ -120,22 +124,16 @@
               Team Contacts
             </th>
             <td>
-              <span class="todo"><a href="mailto:">[team contact name]</a></span> <i class="todo">(0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
+              <a href="mailto:atsushi@w3.org">Atsushi Shimono</a> <i>(0.2 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
             </td>
           </tr>
           <tr>
-            <th>
-              Meeting Schedule
-            </th>
-            <td>
-              <strong>Teleconferences:</strong> <i class="todo">topic-specific calls may be held</i> or <i class="todo">somthing else</i>
-              <br>
-              <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than 3 per year.
-            </td>
+            <th>Meeting Schedule</th>
+            <td><strong>Teleconferences:</strong>Usually once per week.<br>
+            <strong>Face-to-face:</strong> Usually no more than twice per year, including once during the W3C's annual
+            Technical Plenary week.</td>
           </tr>
         </table>
-
-        <p class="issue"><b>Note:</b> The <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has been moved from the essentials table to the <a href="#public">communication section</a>.</p>
       </section>
 
       <section id="background" class="background">
@@ -144,12 +142,18 @@
 
       <section id="scope" class="scope">
         <h2>Scope</h2>
-        <p><i class="todo">What exactly is in scope, and out of scope.
-          For legal review. Be brief.</i></p>
+
+          <p>This group is chartered to develop specifications for the representation of timed text in media.</p>
+
+          <p>Timed text means text synchronized with other timed media, e.g. audio and video (2D, 3D, 360º, AR and VR), and
+          includes captions, subtitles, described video (aka video/audio description), karaoke lyrics, etc.</p>
+    
+          <p>These specifications are intended to be used across the workflow from authoring to end-user presentation, and for both prepared
+          and live applications.</p>
 
         <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>
-            <p>The following features are out of scope, and will not be addressed by this <i class="todo">(Working|Interest)</i> group.</p>
+            <p><i class="todo">The following features are out of scope, and will not be addressed by this Working group.</i></p>
 
             <ul class="out-of-scope">
             </ul>
@@ -162,11 +166,12 @@
           Deliverables
         </h2>
 
-        <p><i class="todo">Updated document status is available on the <a href="https://www.w3.org/groups/wg/[shortname]/publications">group publication status page</a>. [or link to a page this group prefers to use]</i></p>
+        <p>More detailed milestones and updated publication schedules are available on the <a href=
+          "https://www.w3.org/wiki/TimedText/Publications">group publication status page</a>.</p>
 
-        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <span class='todo'>Choose one:</span> <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state
-          <span class='todo'>The Working Group intends to publish the latest state of their work as Candidate Recommendation (with Snapshots) and does not intend to advance their documents to Recommendation</span>.</p>
+        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
 
+<!-- leaving this section as example for update -->
         <section id="normative">
           <h3>
             Normative Specifications
@@ -189,23 +194,73 @@
       <p><b>Other Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/Consortium/Process/#other-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
     </dd>
               </dl></dl>
-
-
         </section>
+<!-- example section ends here -->
 
-        <section id="ig-other-deliverables">
-          <h3>
-            Other Deliverables
-          </h3>
-          <p>
-            Other non-normative documents may be created such as:
-          </p>
-          <ul>
-            <li>Use case and requirement documents;</li>
-            <li>Test suite and implementation report for the specification;</li>
-            <li>Primer or Best Practice documents to support web developers when designing applications.</li>
-          </ul>
-        </section>
+<!-- copy from 2019 charter -->
+<div id="normative">
+  <h3>New Technical Reports</h3>
+
+  <p>The Working Group intends to develop the following Technical Reports:</p>
+
+  <dl>
+    <dt class="spec">
+      <a href="https://www.w3.org/TR/ttml3/">Timed Text Markup Language 3 (TTML3)</a>
+    </dt>
+
+    <dd>
+      <p>This specification defines a content type that represents timed text media for the purpose of
+      interchange among authoring, distribution and playback systems. Timed text is textual information that is
+      intrinsically or extrinsically associated with timing information.</p>
+    </dd>
+
+    <dt id="webvtt" class="spec">
+      <a href="https://www.w3.org/TR/webvtt1/">WebVTT: The Web Video Text Tracks Format</a>
+    </dt>
+
+    <dd>
+      <p>This specification defines WebVTT, the Web Video Text Tracks format. Its main use is for marking up
+      external text track resources in connection with the HTML &lt;track&gt; element. WebVTT files provide
+      captions or subtitles for video content, and also text video descriptions <a href=
+      "http://www.w3.org/TR/media-accessibility-reqs/">[MAUR]</a>, chapters for content navigation,
+      and more generally any form of metadata that is time-aligned with audio or video content.</p>
+    </dd>
+
+    <dt id="adpt" class="spec">TTML Profile for Audio Description</dt>
+
+    <dd>
+      <p>This specification defines a profile of [ <cite><a class="bibref" href=
+      "https://www.w3.org/TR/ttml2/">TTML2</a></cite> ] intended to support audio description script exchange
+      throughout the workflow including production of the script, rendering as voice by recording or text to
+      speech synthesis, and audio mixing.</p>
+    </dd>
+  </dl>
+
+  <p>The Working Group MAY develop additional Recommendation-track and non-Recommendation-track Technical
+  Reports.</p>
+</div>
+
+<div id="revisions">
+  <h3>Existing Technical Reports</h3>
+
+  <p>The Working Group MAY update its <a href="https://www.w3.org/wiki/TimedText/Publications">previously
+  published Technical Reports</a>.</p>
+</div>
+<!-- END here: copy from 2019 charter -->
+
+<div id="ig-other-deliverables">
+  <h3>Other deliverables</h3>
+
+  <p>The Working Group MAY create documents that are not Technical Reports, including:</p>
+
+  <ul>
+    <li>Use case and requirement documents</li>
+
+    <li>Test suite and implementation reports</li>
+
+    <li>Primer or Best Practice documents to support web developers</li>
+  </ul>
+</div>
 
         <section id="timeline">
           <h3>Timeline</h3>
@@ -223,38 +278,119 @@
 
 	<section id="success-criteria">
 	  <h2>Success Criteria</h2>
-	  <p><span class='todo'>Remove this clause if the Group does not intend to move to REC:</span> In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
-	  <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+	  <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
+
+    <p>Each Recommendation-track Technical Report:</p>
+
+    <ul>
+      <li>SHOULD contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.</li>
+      <li>SHOULD have an associated testing plan, starting from the earliest drafts.</li>
+      <li>SHOULD contain a section on accessibility that describes the benefits and impacts, including ways that features defined in the Technical Report can be used to address them, and recommendations for maximising accessibility in implementations.</li>
+      <li>SHOULD address the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media Accessibility User Requirements</a></li>
+      <li>SHOULD contain a section discussing interoperability with previous versions, if any, of the Technical Report, and other relevant specifications.</li>
+    </ul>
+    <p>To promote interoperability, all normative changes made to Technical Reports SHOULD have associated <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
+
+<!-- need to consider of -->
+    <p><i class="todo">NEED TO SELECT AND CONSIDER OF FOLLOWING ITEMS IN THE TEMPLATE.</i></p>
+    <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
 		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
 		recommendations for maximising accessibility in implementations.</p>
-	  <p><span class='todo'>Consider adopting a healthy testing policy, such as:</span> To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
-	  <p><span class='todo'>Consider adding this clause if the Group does not intend to move to REC:</span> All new features should be supported by at least two intents to implement before being incorporated in the specification.</p>
+	  <p>WE HAVE?: <span class='todo'>Consider adopting a healthy testing policy, such as:</span> To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
+	  <p>DROP?: <span class='todo'>Consider adding this clause if the Group does not intend to move to REC:</span> All new features should be supported by at least two intents to implement before being incorporated in the specification.</p>
+<!-- END: need to consider of -->
 	</section>
+  
+
+
+
+    </div>
+  </section>
 
       <section id="coordination">
         <h2>Coordination</h2>
-        <p>For all specifications, this <i class="todo">(Working|Interest)</i> Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
+        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
           accessibility, internationalization, performance, privacy, and security with the relevant Working and
           Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
           Invitation for review must be issued during each major standards-track document transition, including
           <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.  The
-          <i class="todo">(Working|Interest)</i> Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
-          each specification.  The <i class="todo">(Working|Interest)</i> Group is advised to seek a review at least 3 months before first entering
+          Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
+          each specification.  The Working Group is advised to seek a review at least 3 months before first entering
           <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
           to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
 
         <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
 
-      	<p class="todo">In addition to the above catch-all reference to horizontal review which includes accessibility review, please check with chairs and staff contacts of the <a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a> to determine if an additional liaison statement with more specific information about concrete review issues is needed in the list below.</p>
+
 
         <section>
           <h3 id="w3c-coordination">W3C Groups</h3>
+
+
           <dl>
-            <dt><a href=""><i class="todo">[other name]</i> Working Group</a></dt>
-            <dd><i class="todo">[specific nature of liaison]</i></dd>
+            <dt>
+              <a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures (APA) Working Group</a>
+            </dt>
+  
+            <dd>The mission of the Accessible Platform Architectures Working Group (APA WG) is to ensure W3C
+            specifications provide support for accessibility to people with disabilities.</dd>
+  
+            <dt>
+              <a href="https://www.w3.org/community/audio-description/">Audio Description Community Group</a>
+            </dt>
+  
+            <dd>This group developed the first Community report for the Audio Description Profile of TTML2.</dd>
+  
+            <dt>
+              <a href="https://www.w3.org/Style/CSS/">CSS Working Group</a>
+            </dt>
+  
+            <dd>The work of the Working Group coordinates with this group on presentation and layout issues.</dd>
+  
+            <dt>
+              <a href="https://www.w3.org/2011/webtv/">Media and Entertainment Interest Group</a>
+            </dt>
+  
+            <dd>The Media and Entertainment Interest Group provides a forum for Web and TV technical discussions, review
+            existing work, as well as the relationship between services on the Web and TV services, and identifies
+            requirements and potential solutions to ensure that the Web will function well with TV.</dd>
+  
+            <dt>
+              <a href="https://www.w3.org/community/texttracks/">Web Media Text Tracks Community Group</a>
+            </dt>
+  
+            <dd>This group developed the first Community report for the WebVTT format and will continue to explore new
+            features.</dd>
+  
+            <dt>
+              <a href="https://www.w3.org/community/immersive-web/">Immersive Web Community Group</a>
+            </dt>
+  
+            <dd>This group is to help bring high-performance Virtual Reality and Augmented Reality to the open Web.</dd>
+  
+            <dt>
+              <a href="https://www.w3.org/WebPlatform/WG/">Web Platform Working Group</a>
+            </dt>
+  
+            <dd>The HTML specification is intended to provide a semantic-level markup language and associated
+            semantic-level scripting APIs for authoring accessible pages on the Web ranging from static documents to
+            dynamic applications. It includes media elements to present video, audio and video text tracks and their
+            associated APIs.</dd>
+  
+            <dt>
+              <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>
+            </dt>
+  
+            <dd>
+            </dd>
           </dl>
+  
+          <p>Invitation for review SHALL be issued during each major Recommendation-track document transition, including
+          <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>, and when
+          major changes occur in a specification, and SHOULD be issued at least 3 months before <a href=
+          "https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a>.</p>          
 
           <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
           <p class="issue"><b>Note:</b> Do not bury normative text inside the liaison section.
@@ -263,10 +399,59 @@
 
         <section>
           <h3 id="external-coordination">External Organizations</h3>
-          <dl>
-            <dt><a href=""><i class="todo">[other name]</i> Working Group</a></dt>
-            <dd><i class="todo">[specific nature of liaison]</i></dd>
-          </dl>
+
+          <p>The Working Group SHOULD, whenever possible, seek interoperability with other timed text formats, API, and
+            applications.</p>
+    
+            <p>As such, the Working Group SHOULD seek review with the following external organizations.</p>
+    
+            <dl>
+              <dt>
+                <a href="https://www.iso.org/committee/45316.html">ISO/IEC JTC-1/SC-29 WG 11 Moving Picture Experts Group
+                (MPEG)</a>
+              </dt>
+    
+              <dd>This group is developing standards for coded representation of digital audio and video, including
+              MPEG-4.</dd>
+    
+              <dt>
+                <a href="https://www.smpte.org/">Society of Motion Picture and Television Engineers (SMPTE)</a>
+              </dt>
+    
+              <dd>This organization was founded to advance theory and development in the motion imaging field. SMPTE
+              produced extensions to TTML1 that are part of SMPTE-TT.</dd>
+    
+              <dt>
+                <a href="https://www.ebu.ch/home">European Broadcasting Union (EBU)</a>
+              </dt>
+    
+              <dd>The EBU is an association of national broadcasting organizations, facilitating the exchange of
+              audiovisual content. The EBU has developed EBU-TT, an XML-based format for use in subtitling production and
+              exchange, and EBU-TT-D for use in subtitle distribution, both of which are constrained and extended variants
+              of TTML1.</dd>
+    
+              <dt>
+                <a href="https://www.dvb.org/groups/TM">DVB Project: Technical Module (DVB-TM)</a>
+              </dt>
+    
+              <dd>The DVB Project develops specifications for digital television systems, which are turned into standards
+              by international standards bodies such as ETSI or CENELEC. It provides a conduit to other relevant
+              standardisation activities including MPEG for the purpose of meeting the objectives of the DVB Project.</dd>
+    
+              <dt>
+                <a href="https://www.atsc.org/">Advanced Television Systems Committee (ATSC)</a>
+              </dt>
+    
+              <dd>ATSC develops standards for digital television and depends on external standards for digital closed
+              captioning.</dd>
+    
+              <dt>
+                <a href="https://www.3gpp.org/specifications-groups/sa-plenary/sa4-codec">3GPP SA4</a>
+              </dt>
+    
+              <dd>SA WG4 Codec deals with the specifications for speech, audio, video, and multimedia codecs, in both circuit-switched and packet-switched environments.</dd>
+            </dl>
+
         </section>
       </section>
 
@@ -277,13 +462,13 @@
           Participation
         </h2>
         <p>
-          To be successful, this <i class="todo">(Working|Interest)</i> Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the (Working|Interest) Group. There is no minimum requirement for other Participants.
+          To be successful, this Working Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the (Working|Interest) Group. There is no minimum requirement for other Participants.
         </p>
         <p>
           The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
         </p>
         <p>
-          The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+          The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a> (<i class="todo">link need to be replaced by 2021 version if any</i>).
         </p>
         <p>Participants in the group are required (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the
           W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.</p>
@@ -296,23 +481,24 @@
           Communication
         </h2>
         <p id="public">
-          Technical discussions for this <i class="todo">(Working|Interest)</i> Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct public contribution requests.
+          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct public contribution requests.
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href=""><i class="todo">[name]</i> (Working|Interest) Group home page.</a>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/AudioVideo/TT/">Timed Text Working Group home page</a>.
         </p>
         <p>
-          Most <i class="todo">[name]</i> (Working|Interest) Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+          Most <a href="https://www.w3.org/AudioVideo/TT/">Timed Text Working Group</a> teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
-        <p>
-          This group primarily conducts its technical work  <i class="todo">pick one, or both, as appropriate:</i> on the public mailing list <a class="todo" id="public-name" href="mailto:public-[email-list]@w3.org">public-<i class="todo">[email-list]</i>@w3.org</a> (<a class="todo" href="https://lists.w3.org/Archives/Public/public-[email-list]/">archive</a>)
-          <i class="todo">or</i> on <a class="todo" id="public-github" href="[link to Github repo]">GitHub issues</a>.
-          The public is invited to review, discuss and contribute to this work.
-        </p>
-        <p>
-          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
-        </p>
+        <p>This Working Group primarily conducts its technical work on the public mailing list public-tt@w3.org (<a href=
+          "http://lists.w3.org/Archives/Public/public-tt/">archive</a>) or <a id="public-github" href=
+          "https://github.com/w3c/">GitHub issues</a>. The public is invited to review, discuss and contribute to this
+          work.</p>
+    
+          <p>The Working Group MAY use a Member-confidential mailing list member-tt@w3.org (<a href=
+          "http://lists.w3.org/Archives/Member/member-tt/">archive</a>) for administrative purposes and, at the discretion
+          of the Chairs and members of the group, for member-only discussions in special cases when a participant requests
+          such a discussion.</p>
       </section>
 
 
@@ -329,9 +515,9 @@
         <p>
           To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
 
-          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from <span id='cfc'><i class="todo">[pick a duration within:] one week to 10 working days</i></span>, depending on the chair's evaluation of the group consensus on the issue.
+          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period 10 working days, depending on the chair's evaluation of the group consensus on the issue.
 
-          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the <i class="todo">(Working|Interest)</i> Group.
+          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
         </p>
         <p>
           All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
@@ -344,7 +530,6 @@
 
 
       <section id="patentpolicy">
-      <p><i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i></p>
 
         <h2>
           Patent Policy
@@ -352,26 +537,21 @@
         <p>
           This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
 
-          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/[shortname]/ipr">licensing information</a>.
+          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/timed-text/ipr">licensing information</a>.
         </p>
 
-        <h2>Patent Disclosures </h2>
-        <p>The Interest Group provides an opportunity to
-          share perspectives on the topic addressed by this charter. W3C reminds
-          Interest Group participants of their obligation to comply with patent
-          disclosure obligations as set out in <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">Section
-            6</a> of the W3C Patent Policy. While the Interest Group does not
-          produce Recommendation-track documents, when Interest Group
-          participants review Recommendation-track specifications from Working
-          Groups, the patent disclosure obligations do apply. For more information about disclosure obligations for this group,
-          please see the <a href="https://www.w3.org/groups/ig/[shortname]/ipr">licensing information</a>.</p>
       </section>
 
 
 
       <section id="licensing">
         <h2>Licensing</h2>
-        <p>This <i class="todo">(Working|Interest)</i> Group will use the <i class="todo">[pick a license, one of:]</i>  <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> | <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+        <p>This Working Group will use the <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> or <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+
+        <p class="todo">Following line is the current text (2019 charter)</p>
+        <p>For each deliverable the Working Group MAY choose either the <a href=
+          "https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> or the <a href=
+          "https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a>.</p>
       </section>
 
 
@@ -388,70 +568,118 @@
           <h3>
             Charter History
           </h3>
-          <p class="issue"><b>Note:</b>Display this table and update it when appropriate. Requirements for charter extension history are documented in the <a href="https://www.w3.org/Guide/process/charter.html#extension">Charter Guidebook (section 4)</a>.</p>
 
           <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 5.2.3)</a>:</p>
 
           <table class="history">
             <tbody>
               <tr>
-                <th>
-                  Charter Period
-                </th>
-                <th>
-                  Start Date
-                </th>
-                <th>
-                  End Date
-                </th>
-                <th>
-                  Changes
-                </th>
+                <th>Charter Period</th>
+                <th>Start Date</th>
+                <th>End Date</th>
+                <th>Changes</th>
               </tr>
+  
               <tr>
                 <th>
-                  <a class="todo" href="">Initial Charter</a>
+                  <a href="http://www.w3.org/2008/01/timed-text-wg">Initial Charter</a>
                 </th>
-                <td>
-                  <i class="todo">[dd monthname yyyy]</i>
-                </td>
-                <td>
-                  <i class="todo">[dd monthname yyyy]</i>
-                </td>
-                <td>
-                  <i class="todo">none</i>
-                </td>
+                <td>2008-08-15</td>
+                <td>2010-06-30</td>
+                <td>Restarted the Working Group</td>
               </tr>
+  
               <tr>
                 <th>
-                  <a class="todo" href="">Charter Extension</a>
+                  <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2011JanMar/0026.html">Charter
+                  Extension</a>
                 </th>
                 <td>
-                  <i class="todo">[dd monthname yyyy]</i>
                 </td>
-                <td>
-                  <i class="todo">[dd monthname yyyy]</i>
-                </td>
-                <td>
-                  <i class="todo">none</i>
-                </td>
+                <td>2011-03-31</td>
+                <td>none</td>
               </tr>
+  
               <tr>
                 <th>
-                  <a class="todo" href="">Rechartered</a>
+                  <a href="http://www.w3.org/2012/07/ttml-charter.html">Rechartered</a>
+                </th>
+                <td>2012-07-25</td>
+                <td>2014-01-31</td>
+                <td>TTML 1.0 2nd edition, TTML 1.1</td>
+              </tr>
+  
+              <tr>
+                <th>
+                  <a href="http://www.w3.org/2014/03/timed-text-charter.html">Rechartered</a>
+                </th>
+                <td>2014-03-27</td>
+                <td>2016-03-30</td>
+                <td>WebVTT 1.0, IMSC 1.0</td>
+              </tr>
+  
+              <tr>
+                <th>
+                  <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2016AprJun/0008.html">Charter
+                  Extension</a>
                 </th>
                 <td>
-                  <i class="todo">[dd monthname yyyy]</i>
                 </td>
+                <td>2016-05-31</td>
+                <td>none</td>
+              </tr>
+  
+              <tr>
+                <th>
+                  <a href="https://www.w3.org/2016/05/timed-text-charter.html">Rechartered</a>
+                </th>
+                <td>2016-05-19</td>
+                <td>2018-03-31</td>
+                <td>none</td>
+              </tr>
+  
+              <tr>
+                <th>
+                  <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2018AprJun/0004.html">Charter
+                  Extension</a>
+                </th>
                 <td>
-                  <i class="todo">[dd monthname yyyy]</i>
                 </td>
-                <td>
-                  <p class="todo">[description of change to charter, with link to new deliverable item in charter] <b>Note:</b> use the class <code>new</code> for all new deliverables, for ease of recognition.</p>
+                <td>2018-05-31</td>
+                <td>none</td>
+              </tr>
+  
+              <tr>
+                <th>
+                  <a href="https://www.w3.org/2018/05/timed-text-charter.html">Rechartered</a>
+                </th>
+                <td>2018-05-30</td>
+                <td>2020-05-31</td>
+                <td>none</td>
+              </tr>
+  
+              <tr>
+                <th>
+                  <a href="https://www.w3.org/2019/11/timed-text-wg-charter.html">Rechartered</a>
+                </th>
+                <td>2019-11-28</td>
+                <td>2021-12-31</td>
+                <td>TTML3, TTML Profile for Audio Description
                 </td>
+              </tr>  
+
+              <tr>
+                <th>
+                  <a href="" class="todo">Rechartered</a>
+                </th>
+                <td></td>
+                <td></td>
+                <td></td>
               </tr>
             </tbody>
           </table>
+
+          
         </section>
 
         <section id="changelog">
@@ -473,7 +701,7 @@
 
     <footer>
       <address>
-        <i class="todo"><a href="mailto:">[team contact name]</a></i>
+        <a href="mailto:atsushi@w3.org">Atsushi Shimono, Team Contact.</a>
       </address>
 
       <p class="copyright">

--- a/index.html
+++ b/index.html
@@ -264,15 +264,7 @@
 
         <section id="timeline">
           <h3>Timeline</h3>
-            <p class="todo">Put here a timeline view of all deliverables.</p>
-            <ul class="todo">
-              <li>Month YYYY: First teleconference</li>
-              <li>Month YYYY: First face-to-face meeting</li>
-              <li>Month YYYY: Requirements and Use Cases for FooML</li>
-              <li>Month YYYY: FPWD for FooML</li>
-              <li>Month YYYY: Requirements and Use Cases for BarML</li>
-              <li>Month YYYY: FPWD FooML Primer</li>
-            </ul>
+            <p>Current timelines are documented at [WG wiki page](https://www.w3.org/wiki/TimedText/Publications) and will be updated on an occasional basis.</p>
         </section>
       </section>
 
@@ -290,7 +282,8 @@
       <li>SHOULD contain a section discussing interoperability with previous versions, if any, of the Technical Report, and other relevant specifications.</li>
     </ul>
     <p>To promote interoperability, all normative changes made to Technical Reports SHOULD have associated <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
-	  <p>There should be testing plans for each specification, starting from the earliest drafts. To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
+    <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+    <p>There should be testing plans for each specification, starting from the earliest drafts. To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
     <p>Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
 		recommendations for maximising accessibility in implementations.</p>
 	  <p>DROP?: <span class='todo'>Consider adding this clause if the Group does not intend to move to REC:</span> All new features should be supported by at least two intents to implement before being incorporated in the specification.</p>

--- a/index.html
+++ b/index.html
@@ -1,16 +1,22 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8">
-  <title>Timed Text Working Group Charter</title>
-  <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
-  <link rel="stylesheet" type="text/css" href="https://www.w3.org/Guide/pubrules-style.css">
-  <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css">
-  <style type="text/css">
+  <head>
+    <meta charset="utf-8">
+
+    <title><i class="todo">[name]</i> (Working|Interest) Group Charter</title>
+
+    <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css">
+    <style>
+      main {
+        max-width: 60em;
+        margin: 0 auto;
+      }
+
       ul#navbar {
         font-size: small;
       }
-
 
       dt.spec {
         font-weight: bold;
@@ -40,613 +46,452 @@
       footer {
         font-size: small;
       }
-
-    .note {
-    background-color: #FAFAD2;
-    }
-
-    .note::before {
-    content: "NOTE: ";
-    }
-
-  </style>
-</head>
-<body>
-  <header id="header">
-    <aside>
-      <ul id="navbar">
-        <li>
-          <a href="#scope">Scope</a>
-        </li>
-
-        <li>
-          <a href="#deliverables">Deliverables</a>
-        </li>
-
-        <li>
-          <a href="#success">Success Criteria</a>
-        </li>
-
-        <li>
-          <a href="#coordination">Coordination</a>
-        </li>
-
-        <li>
-          <a href="#participation">Participation</a>
-        </li>
-
-        <li>
-          <a href="#communication">Communication</a>
-        </li>
-
-        <li>
-          <a href="#decisions">Decision Policy</a>
-        </li>
-
-        <li>
-          <a href="#patentpolicy">Patent Policy</a>
-        </li>
-
-        <li>
-          <a href="#licensing">Licensing</a>
-        </li>
-
-        <li>
-          <a href="#about">About this Charter</a>
-        </li>
-      </ul>
-    </aside>
-
-    <p><a href="https://www.w3.org/"><img alt="W3C" src="https://www.w3.org/Icons/w3c_home" height="48" width="72"></a>
-    </p>
-  </header>
-
-  <main>
-    <h1 id="title">Timed Text Working Group Charter</h1>
-
-    <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/AudioVideo/TT/">Timed Text
-    Working Group</a> is to develop W3C Recommendations for the representation of timed text in media, including
-    developing and maintaining new versions of the <a href="https://www.w3.org/TR/ttml/">Timed Text Markup Language</a> (TTML) and <a href="https://www.w3.org/TR/webvtt/">WebVTT</a> (Web Video Text Tracks)
-    based on implementation experience and interoperability feedback, and the creation of semantic mappings between
-    those languages.</p>
-
-    <div class="noprint">
-      <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/34314/join">Join the Timed Text Working
-      Group</a>.<a href="https://www.w3.org/2004/01/pp-impl/#####/join"></a></p>
-    </div>
-
-    <section id="details">
-      <table class="summary-table">
-        <tbody>
-          <tr id="Duration">
-            <th>Start date</th>
-            <td>28 November 2019</td>
-          </tr>
-
-          <tr id="Duration">
-            <th>End date</th>
-            <td>31 December 2021</td>
-          </tr>
-
-          <tr>
-            <th>Charter extension</th>
-            <td>
-              See <a href="#history">Change History</a>.
-            </td>
-          </tr>
-
-          <tr>
-            <th>Chairs</th>
-            <td>Nigel Megitt (BBC),<br>
-              Gary Katsevman (Brightcove)</td>
-          </tr>
-
-          <tr>
-            <th>Team Contacts</th>
-            <td>
-              <a href="mailto:atsushi@w3.org">Atsushi Shimono</a> <i>(0.2 <abbr title=
-              "Full-Time Equivalent">FTE</abbr>)</i>
-            </td>
-          </tr>
-
-          <tr>
-            <th>Meeting Schedule</th>
-            <td><strong>Teleconferences:</strong>Usually once per week.<br>
-            <strong>Face-to-face:</strong> Usually no more than twice per year, including once during the W3C's annual
-            Technical Plenary week.</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-
-    <section id="scope" class="scope">
-      <h2>Scope</h2>
-
-      <p>This group is chartered to develop specifications for the representation of timed text in media.</p>
-
-      <p>Timed text means text synchronized with other timed media, e.g. audio and video (2D, 3D, 360º, AR and VR), and
-      includes captions, subtitles, described video (aka video/audio description), karaoke lyrics, etc.</p>
-
-      <p>These specifications are intended to be used across the workflow from authoring to end-user presentation, and for both prepared
-      and live applications.</p>
-
-      <section id="success">
-        <div>
-          <h3>Success Criteria</h3>
-
-          <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title=
-          "Proposed Recommendation">Proposed Recommendation</a>, each Recommendation-track Technical Report SHOULD have
-          <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent
-          implementations</a> of each feature defined in the Technical Report.</p>
-
-          <p>Each Recommendation-track Technical Report:</p>
-
-          <ul>
-            <li>SHOULD contain a section detailing all known security and privacy implications for implementers, Web
-            authors, and end users.</li>
-
-            <li>SHOULD have an associated testing plan, starting from the earliest drafts.</li>
-
-            <li>SHOULD contain a section on accessibility that describes the benefits and impacts, including ways that
-            features defined in the Technical Report can be used to address them, and recommendations for maximising
-            accessibility in implementations.</li>
-
-            <li>SHOULD address the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media Accessibility User
-            Requirements</a>
-            </li>
-
-            <li>SHOULD contain a section discussing interoperability with previous versions, if any, of the Technical
-            Report, and other relevant specifications.</li>
-          </ul>
-
-          <p>To promote interoperability, all normative changes made to Technical Reports SHOULD have associated
-          <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
-        </div>
-      </section>
-    </section>
-
-    <section id="deliverables">
-      <h2>Deliverables</h2>
-
-      <p>More detailed milestones and updated publication schedules are available on the <a href=
-      "https://www.w3.org/wiki/TimedText/Publications">group publication status page</a>.</p>
-
-      <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected
-      completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a
-      stable state.</p>
-
-      <div id="normative">
-        <h3>New Technical Reports</h3>
-
-        <p>The Working Group intends to develop the following Technical Reports:</p>
-
-        <dl>
-          <dt class="spec">
-            <a href="https://www.w3.org/TR/ttml3/">Timed Text Markup Language 3 (TTML3)</a>
-          </dt>
-
-          <dd>
-            <p>This specification defines a content type that represents timed text media for the purpose of
-            interchange among authoring, distribution and playback systems. Timed text is textual information that is
-            intrinsically or extrinsically associated with timing information.</p>
-          </dd>
-
-          <dt id="webvtt" class="spec">
-            <a href="https://www.w3.org/TR/webvtt1/">WebVTT: The Web Video Text Tracks Format</a>
-          </dt>
-
-          <dd>
-            <p>This specification defines WebVTT, the Web Video Text Tracks format. Its main use is for marking up
-            external text track resources in connection with the HTML &lt;track&gt; element. WebVTT files provide
-            captions or subtitles for video content, and also text video descriptions <a href=
-            "http://www.w3.org/TR/media-accessibility-reqs/">[MAUR]</a>, chapters for content navigation,
-            and more generally any form of metadata that is time-aligned with audio or video content.</p>
-          </dd>
-
-          <dt id="adpt" class="spec">TTML Profile for Audio Description</dt>
-
-          <dd>
-            <p>This specification defines a profile of [ <cite><a class="bibref" href=
-            "https://www.w3.org/TR/ttml2/">TTML2</a></cite> ] intended to support audio description script exchange
-            throughout the workflow including production of the script, rendering as voice by recording or text to
-            speech synthesis, and audio mixing.</p>
-          </dd>
-        </dl>
-
-        <p>The Working Group MAY develop additional Recommendation-track and non-Recommendation-track Technical
-        Reports.</p>
-      </div>
-
-      <div id="revisions">
-        <h3>Existing Technical Reports</h3>
-
-        <p>The Working Group MAY update its <a href="https://www.w3.org/wiki/TimedText/Publications">previously
-        published Technical Reports</a>.</p>
-      </div>
-
-      <div id="ig-other-deliverables">
-        <h3>Other deliverables</h3>
-
-        <p>The Working Group MAY create documents that are not Technical Reports, including:</p>
-
-        <ul>
-          <li>Use case and requirement documents</li>
-
-          <li>Test suite and implementation reports</li>
-
-          <li>Primer or Best Practice documents to support web developers</li>
+    </style>
+  </head>
+  <body>
+    <header id="header">
+      <aside>
+        <ul id="navbar">
+          <li><a href="#background">Background</a></li>
+          <li><a href="#scope">Scope</a></li>
+          <li><a href="#deliverables">Deliverables</a></li>
+		  <li><a href="#success-criteria">Success Criteria</a></li>
+          <li><a href="#coordination">Coordination</a></li>
+          <li><a href="#participation">Participation</a></li>
+          <li><a href="#communication">Communication</a></li>
+          <li><a href="#decisions">Decision Policy</a></li>
+          <i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i>
+          <li><a href="#patentpolicy">Patent Policy</a></li>
+          <li><a href="#patentpolicy">Patent Disclosures</a></li>
+          <li><a href="#licensing">Licensing</a></li>
+          <li><a href="#about">About this Charter</a></li>
         </ul>
+      </aside>
+      <p>
+        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a>
+      </p>
+    </header>
+
+
+    <main>
+      <h1 id="title"><i class="todo">PROPOSED [name]</i> (Working|Interest) Group Charter</h1>
+      <!-- delete PROPOSED after AC review completed -->
+
+      <p class="mission">The <strong>mission</strong> of the <a href=""><i class="todo">[name]</i> (Working|Interest) Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
+
+      <div class="noprint">
+        <p class="join"><a href="https://www.w3.org/groups/wg/[shortname]/join">Join the <i class="todo">[name]</i> (Working|Interest) Group.</a></p>
       </div>
-    </section>
 
-    <section id="coordination">
-      <h2>Coordination</h2>
+         <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
+      on <i class="todo"><a href="https://github.com/w3c/@@">GitHub</a>.
 
-      <div>
-        <h3 id="w3c-coordination">W3C Groups</h3>
+    Feel free to raise <a href="https://github.com/w3c/@@/issues">issues</a></i>.
+          </p>
 
-        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal review</a> for
+      <section id="details">
+        <table class="summary-table">
+          <tr id="Duration">
+            <th>
+              Start date
+            </th>
+            <td>
+              <i class="todo">[dd monthname yyyy] (date of the "Call for Participation", when the charter is approved)</i>
+            </td>
+          </tr>
+          <tr id="CharterEnd">
+            <th>
+              End date
+            </th>
+            <td>
+              <i class="todo">[dd monthname yyyy]</i> (Start date + 2 years)
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Chairs
+            </th>
+            <td>
+              <i class="todo">[chair name] (affiliation)</i>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Team Contacts
+            </th>
+            <td>
+              <span class="todo"><a href="mailto:">[team contact name]</a></span> <i class="todo">(0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Meeting Schedule
+            </th>
+            <td>
+              <strong>Teleconferences:</strong> <i class="todo">topic-specific calls may be held</i> or <i class="todo">somthing else</i>
+              <br>
+              <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than 3 per year.
+            </td>
+          </tr>
+        </table>
+
+        <p class="issue"><b>Note:</b> The <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has been moved from the essentials table to the <a href="#public">communication section</a>.</p>
+      </section>
+
+      <section id="background" class="background">
+        <p><i class="todo">Brief background of landscape, technology, and relationship to the Web, users, developers, implementers, and industry.</i></p>
+      </section>
+
+      <section id="scope" class="scope">
+        <h2>Scope</h2>
+        <p><i class="todo">What exactly is in scope, and out of scope.
+          For legal review. Be brief.</i></p>
+
+        <section id="section-out-of-scope">
+          <h3 id="out-of-scope">Out of Scope</h3>
+            <p>The following features are out of scope, and will not be addressed by this <i class="todo">(Working|Interest)</i> group.</p>
+
+            <ul class="out-of-scope">
+            </ul>
+        </section>
+
+      </section>
+
+      <section id="deliverables">
+        <h2>
+          Deliverables
+        </h2>
+
+        <p><i class="todo">Updated document status is available on the <a href="https://www.w3.org/groups/wg/[shortname]/publications">group publication status page</a>. [or link to a page this group prefers to use]</i></p>
+
+        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <span class='todo'>Choose one:</span> <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state
+          <span class='todo'>The Working Group intends to publish the latest state of their work as Candidate Recommendation (with Snapshots) and does not intend to advance their documents to Recommendation</span>.</p>
+
+        <section id="normative">
+          <h3>
+            Normative Specifications
+          </h3>
+          <p>
+            The <i class="todo">(Working|Interest)</i> Group will deliver the following W3C normative specifications:
+          </p>
+          <dl>
+            <dt id="web-foo" class="spec"><a href="#">Web <i class="todo">[spec name]</i></a></dt>
+            <dd>
+              <p>This specification defines <i class="todo">[concrete description]</i>.</p>
+
+              <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">Member Submission</a> | <a href="#">Adopted from WG/CG Foo</a> | <a href="#">Working Draft</a>]</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
+   <dl><dt>
+    <p class="todo">Per <a href="https://www.w3.org/Consortium/Process/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing <a href='https://www.w3.org/Consortium/Process/#exclusion-draft'>Exclusion Draft</a>: </p>
+      <p><b>Adopted Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://www.w3.org/Consortium/Process/#adopted-draft">Adopted Draft</a></span> which will serve as the basis for work on the deliverable.
+      <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/Consortium/Process/#exclusion-draft'>Exclusion Draft</a></span>.
+        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
+      <p><b>Other Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/Consortium/Process/#other-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
+    </dd>
+              </dl></dl>
+
+
+        </section>
+
+        <section id="ig-other-deliverables">
+          <h3>
+            Other Deliverables
+          </h3>
+          <p>
+            Other non-normative documents may be created such as:
+          </p>
+          <ul>
+            <li>Use case and requirement documents;</li>
+            <li>Test suite and implementation report for the specification;</li>
+            <li>Primer or Best Practice documents to support web developers when designing applications.</li>
+          </ul>
+        </section>
+
+        <section id="timeline">
+          <h3>Timeline</h3>
+            <p class="todo">Put here a timeline view of all deliverables.</p>
+            <ul class="todo">
+              <li>Month YYYY: First teleconference</li>
+              <li>Month YYYY: First face-to-face meeting</li>
+              <li>Month YYYY: Requirements and Use Cases for FooML</li>
+              <li>Month YYYY: FPWD for FooML</li>
+              <li>Month YYYY: Requirements and Use Cases for BarML</li>
+              <li>Month YYYY: FPWD FooML Primer</li>
+            </ul>
+        </section>
+      </section>
+
+	<section id="success-criteria">
+	  <h2>Success Criteria</h2>
+	  <p><span class='todo'>Remove this clause if the Group does not intend to move to REC:</span> In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
+	  <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
+	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
+		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
+		recommendations for maximising accessibility in implementations.</p>
+	  <p><span class='todo'>Consider adopting a healthy testing policy, such as:</span> To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
+	  <p><span class='todo'>Consider adding this clause if the Group does not intend to move to REC:</span> All new features should be supported by at least two intents to implement before being incorporated in the specification.</p>
+	</section>
+
+      <section id="coordination">
+        <h2>Coordination</h2>
+        <p>For all specifications, this <i class="todo">(Working|Interest)</i> Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
           accessibility, internationalization, performance, privacy, and security with the relevant Working and
           Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
           Invitation for review must be issued during each major standards-track document transition, including
           <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.  The
-          Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
-          each specification.  The Working Group is advised to seek a review at least 3 months before first entering
+          <i class="todo">(Working|Interest)</i> Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
+          each specification.  The <i class="todo">(Working|Interest)</i> Group is advised to seek a review at least 3 months before first entering
           <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
           to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
 
-        <dl>
-          <dt>
-            <a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures (APA) Working Group</a>
-          </dt>
-
-          <dd>The mission of the Accessible Platform Architectures Working Group (APA WG) is to ensure W3C
-          specifications provide support for accessibility to people with disabilities.</dd>
-
-          <dt>
-            <a href="https://www.w3.org/community/audio-description/">Audio Description Community Group</a>
-          </dt>
-
-          <dd>This group developed the first Community report for the Audio Description Profile of TTML2.</dd>
-
-          <dt>
-            <a href="https://www.w3.org/Style/CSS/">CSS Working Group</a>
-          </dt>
-
-          <dd>The work of the Working Group coordinates with this group on presentation and layout issues.</dd>
-
-          <dt>
-            <a href="https://www.w3.org/2011/webtv/">Media and Entertainment Interest Group</a>
-          </dt>
-
-          <dd>The Media and Entertainment Interest Group provides a forum for Web and TV technical discussions, review
-          existing work, as well as the relationship between services on the Web and TV services, and identifies
-          requirements and potential solutions to ensure that the Web will function well with TV.</dd>
-
-          <dt>
-            <a href="https://www.w3.org/community/texttracks/">Web Media Text Tracks Community Group</a>
-          </dt>
-
-          <dd>This group developed the first Community report for the WebVTT format and will continue to explore new
-          features.</dd>
-
-          <dt>
-            <a href="https://www.w3.org/community/immersive-web/">Immersive Web Community Group</a>
-          </dt>
-
-          <dd>This group is to help bring high-performance Virtual Reality and Augmented Reality to the open Web.</dd>
-
-          <dt>
-            <a href="https://www.w3.org/WebPlatform/WG/">Web Platform Working Group</a>
-          </dt>
-
-          <dd>The HTML specification is intended to provide a semantic-level markup language and associated
-          semantic-level scripting APIs for authoring accessible pages on the Web ranging from static documents to
-          dynamic applications. It includes media elements to present video, audio and video text tracks and their
-          associated APIs.</dd>
-
-          <dd>
-          </dd>
-
-          <dt>
-            <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>
-          </dt>
-
-          <dd>
-          </dd>
-        </dl>
-
-        <p>Invitation for review SHALL be issued during each major Recommendation-track document transition, including
-        <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>, and when
-        major changes occur in a specification, and SHOULD be issued at least 3 months before <a href=
-        "https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a>.</p>
-
-        <h3 id="external-coordination">External Organizations</h3>
-
-        <p>The Working Group SHOULD, whenever possible, seek interoperability with other timed text formats, API, and
-        applications.</p>
-
-        <p>As such, the Working Group SHOULD seek review with the following external organizations.</p>
-
-        <dl>
-          <dt>
-            <a href="https://www.iso.org/committee/45316.html">ISO/IEC JTC-1/SC-29 WG 11 Moving Picture Experts Group
-            (MPEG)</a>
-          </dt>
-
-          <dd>This group is developing standards for coded representation of digital audio and video, including
-          MPEG-4.</dd>
-
-          <dt>
-            <a href="https://www.smpte.org/">Society of Motion Picture and Television Engineers (SMPTE)</a>
-          </dt>
-
-          <dd>This organization was founded to advance theory and development in the motion imaging field. SMPTE
-          produced extensions to TTML1 that are part of SMPTE-TT.</dd>
-
-          <dt>
-            <a href="https://www.ebu.ch/home">European Broadcasting Union (EBU)</a>
-          </dt>
-
-          <dd>The EBU is an association of national broadcasting organizations, facilitating the exchange of
-          audiovisual content. The EBU has developed EBU-TT, an XML-based format for use in subtitling production and
-          exchange, and EBU-TT-D for use in subtitle distribution, both of which are constrained and extended variants
-          of TTML1.</dd>
-
-          <dt>
-            <a href="https://www.dvb.org/groups/TM">DVB Project: Technical Module (DVB-TM)</a>
-          </dt>
-
-          <dd>The DVB Project develops specifications for digital television systems, which are turned into standards
-          by international standards bodies such as ETSI or CENELEC. It provides a conduit to other relevant
-          standardisation activities including MPEG for the purpose of meeting the objectives of the DVB Project.</dd>
-
-          <dt>
-            <a href="https://www.atsc.org/">Advanced Television Systems Committee (ATSC)</a>
-          </dt>
-
-          <dd>ATSC develops standards for digital television and depends on external standards for digital closed
-          captioning.</dd>
-
-          <dt>
-            <a href="https://www.3gpp.org/specifications-groups/sa-plenary/sa4-codec">3GPP SA4</a>
-          </dt>
-
-          <dd>SA WG4 Codec deals with the specifications for speech, audio, video, and multimedia codecs, in both circuit-switched and packet-switched environments.</dd>
-        </dl>
-      </div>
-    </section>
-
-    <section class="participation">
-      <h2 id="participation">Participation</h2>
-
-      <p>To be successful, the Working Group is expected to have 6 or more active participants for its duration,
-      including representatives from the key implementors of this specification, and active Editors and Test Leads for
-      each specification. The Chairs and specification Editors are expected to contribute half of a working day per
-      week towards the Working Group. There is no minimum requirement for other Participants.</p>
-
-      <p>The Working Group encourages questions, comments and issues on its public mailing lists and document
-      repositories, as described in <a href="#communication">Communication</a>.</p>
-
-      <p>The Working Group also welcomes non-Members to contribute technical submissions for consideration upon their
-      agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.</p>
-    </section>
-
-    <section id="communication">
-      <h2>Communication</h2>
-
-      <p id="public">Technical discussions for this Working Group are conducted in <a href=
-      "https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from
-      teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue
-      tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts
-      and Editor's Drafts of specifications will be developed on a public repository, and MAY permit direct public
-      contribution requests. The meetings themselves are not open to public participation, however.</p>
-
-      <p>Information about the Working Group (including details about deliverables, issues, actions, status,
-      participants, and meetings) will be available from the <a href="https://www.w3.org/AudioVideo/TT/">Timed Text
-      Working Group home page</a>.</p>
-
-      <p>Most <a href="https://www.w3.org/AudioVideo/TT/">Timed Text Working Group</a> teleconferences will focus on
-      discussion of particular specifications, and will be conducted on an as-needed basis.</p>
-
-      <p>This Working Group primarily conducts its technical work on the public mailing list public-tt@w3.org (<a href=
-      "http://lists.w3.org/Archives/Public/public-tt/">archive</a>) or <a id="public-github" href=
-      "https://github.com/w3c/">GitHub issues</a>. The public is invited to review, discuss and contribute to this
-      work.</p>
-
-      <p>The Working Group MAY use a Member-confidential mailing list member-tt@w3.org (<a href=
-      "http://lists.w3.org/Archives/Member/member-tt/">archive</a>) for administrative purposes and, at the discretion
-      of the Chairs and members of the group, for member-only discussions in special cases when a participant requests
-      such a discussion.</p>
-    </section>
-
-    <section id="decisions">
-      <h2>Decision Policy</h2>
-
-      <p>This Working Group will seek to make decisions through consensus and due process, per the <a href=
-      "https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 3.3</a>). Typically, an editor
-      or other participant makes an initial proposal, which is then refined in discussion with members of the Working
-      Group and other reviewers, and consensus emerges with little formal voting being required.</p>
-
-      <p>However, if a decision is necessary for timely progress, but consensus is not achieved after careful
-      consideration of the range of views presented, the Chairs MAY call for a Working Group vote, and record a
-      decision along with any objections.</p>
-
-      <p>To afford asynchronous decisions and organizational deliberation, any resolution (including publication
-      decisions) taken in a face-to-face meeting or teleconference will be considered provisional. A call for consensus
-      (CfC) will be issued for all resolutions (for example, via email and/or web-based survey), with a response period
-      of 10 working days. If no objections are raised on the mailing list by the end of the response period, the
-      resolution will be considered to have consensus as a resolution of the Working Group.</p>
-
-      <p>All decisions made by the Working Group SHOULD be considered resolved unless and until new information becomes
-      available, or unless reopened at the discretion of the Chairs or the Director.</p>
-
-      <p>This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C
-      Process Document (Section 3.4, Votes)</a>, and includes no voting procedures beyond what the Process Document
-      requires.</p>
-    </section>
-
-    <section id="patentpolicy">
-      <h2>Patent Policy</h2>
-
-      <p>This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent
-      Policy</a> (Version of 5 February 2004 updated 1 August 2017). To promote the widest adoption of Web standards,
-      W3C seeks to issue Recommendations that can be implemented, according to this policy, on a Royalty-Free basis.
-      For more information about disclosure obligations for this group, please see the <a href=
-      "https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.</p>
-    </section>
-
-    <section id="licensing">
-      <h2>Licensing</h2>
-
-      <p>For each deliverable the Working Group MAY choose either the <a href=
-      "https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> or the <a href=
-      "https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a>.</p>
-    </section>
-
-    <section id="about">
-      <h2>About this Charter</h2>
-
-      <p>This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section
-      5.2</a> of the <a href="https://www.w3.org/Consortium/Process">Process Document</a>. In the event of a conflict
-      between this document or the provisions of any charter and the W3C Process, the W3C Process SHALL take
-      precedence.</p>
-
-      <section id="history">
-        <h3>Charter History</h3>
-
-        <p>The following table lists details of all changes from the initial charter, per the <a href=
-        "https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 5.2.3)</a>:</p>
-
-        <table class="history">
-          <tbody>
-            <tr>
-              <th>Charter Period</th>
-              <th>Start Date</th>
-              <th>End Date</th>
-              <th>Changes</th>
-            </tr>
-
-            <tr>
-              <th>
-                <a href="http://www.w3.org/2008/01/timed-text-wg">Initial Charter</a>
-              </th>
-              <td>2008-08-15</td>
-              <td>2010-06-30</td>
-              <td>Restarted the Working Group</td>
-            </tr>
-
-            <tr>
-              <th>
-                <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2011JanMar/0026.html">Charter
-                Extension</a>
-              </th>
-              <td>
-              </td>
-              <td>2011-03-31</td>
-              <td>none</td>
-            </tr>
-
-            <tr>
-              <th>
-                <a href="http://www.w3.org/2012/07/ttml-charter.html">Rechartered</a>
-              </th>
-              <td>2012-07-25</td>
-              <td>2014-01-31</td>
-              <td>TTML 1.0 2nd edition, TTML 1.1</td>
-            </tr>
-
-            <tr>
-              <th>
-                <a href="http://www.w3.org/2014/03/timed-text-charter.html">Rechartered</a>
-              </th>
-              <td>2014-03-27</td>
-              <td>2016-03-30</td>
-              <td>WebVTT 1.0, IMSC 1.0</td>
-            </tr>
-
-            <tr>
-              <th>
-                <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2016AprJun/0008.html">Charter
-                Extension</a>
-              </th>
-              <td>
-              </td>
-              <td>2016-05-31</td>
-              <td>none</td>
-            </tr>
-
-            <tr>
-              <th>
-                <a href="https://www.w3.org/2016/05/timed-text-charter.html">Rechartered</a>
-              </th>
-              <td>2016-05-19</td>
-              <td>2018-03-31</td>
-              <td>none</td>
-            </tr>
-
-            <tr>
-              <th>
-                <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2018AprJun/0004.html">Charter
-                Extension</a>
-              </th>
-              <td>
-              </td>
-              <td>2018-05-31</td>
-              <td>none</td>
-            </tr>
-
-            <tr>
-              <th>
-                <a href="https://www.w3.org/2018/05/timed-text-charter.html">Rechartered</a>
-              </th>
-              <td>2018-05-30</td>
-              <td>2020-05-31</td>
-              <td>none</td>
-            </tr>
-
-            <tr>
-              <th>
-                <a href="https://www.w3.org/2019/11/timed-text-wg-charter.html">Rechartered</a>
-              </th>
-              <td>2019-11-28</td>
-              <td>2021-12-31</td>
-              <td>TTML3, TTML Profile for Audio Description
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
+
+      	<p class="todo">In addition to the above catch-all reference to horizontal review which includes accessibility review, please check with chairs and staff contacts of the <a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a> to determine if an additional liaison statement with more specific information about concrete review issues is needed in the list below.</p>
+
+        <section>
+          <h3 id="w3c-coordination">W3C Groups</h3>
+          <dl>
+            <dt><a href=""><i class="todo">[other name]</i> Working Group</a></dt>
+            <dd><i class="todo">[specific nature of liaison]</i></dd>
+          </dl>
+
+          <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
+          <p class="issue"><b>Note:</b> Do not bury normative text inside the liaison section.
+            Instead, put it in the scope section.</p>
+        </section>
+
+        <section>
+          <h3 id="external-coordination">External Organizations</h3>
+          <dl>
+            <dt><a href=""><i class="todo">[other name]</i> Working Group</a></dt>
+            <dd><i class="todo">[specific nature of liaison]</i></dd>
+          </dl>
+        </section>
       </section>
 
-      <section id="change_log">
-        <h3>Change Log</h3>
-        <p>Note: those modifications were done after the charter was approved by the Director.</p>
-        <dl>
-          <dt>2020-03-26</dt>
-          <dd>Charter History table for this period has been updated with correct dates and changes.
-        </dl>
+
+
+      <section class="participation">
+        <h2 id="participation">
+          Participation
+        </h2>
+        <p>
+          To be successful, this <i class="todo">(Working|Interest)</i> Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the (Working|Interest) Group. There is no minimum requirement for other Participants.
+        </p>
+        <p>
+          The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
+        </p>
+        <p>
+          The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+        </p>
+        <p>Participants in the group are required (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the
+          W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.</p>
       </section>
 
-    </section>
-  </main>
 
-  <hr>
 
-  <footer>
-    <address>
-      Atsushi Shimono, Team Contact.
-    </address>
+      <section id="communication">
+        <h2>
+          Communication
+        </h2>
+        <p id="public">
+          Technical discussions for this <i class="todo">(Working|Interest)</i> Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct public contribution requests.
+        The meetings themselves are not open to public participation, however.
+        </p>
+        <p>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href=""><i class="todo">[name]</i> (Working|Interest) Group home page.</a>
+        </p>
+        <p>
+          Most <i class="todo">[name]</i> (Working|Interest) Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+        </p>
+        <p>
+          This group primarily conducts its technical work  <i class="todo">pick one, or both, as appropriate:</i> on the public mailing list <a class="todo" id="public-name" href="mailto:public-[email-list]@w3.org">public-<i class="todo">[email-list]</i>@w3.org</a> (<a class="todo" href="https://lists.w3.org/Archives/Public/public-[email-list]/">archive</a>)
+          <i class="todo">or</i> on <a class="todo" id="public-github" href="[link to Github repo]">GitHub issues</a>.
+          The public is invited to review, discuss and contribute to this work.
+        </p>
+        <p>
+          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
+        </p>
+      </section>
 
-    <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©2019
-    <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a>® ( <a href=
-    "https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href=
-    "https://www.ercim.eu/"><abbr title=
-    "European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href=
-    "https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a> ), All Rights Reserved.
-    <abbr title="World Wide Web Consortium">W3C</abbr> <a href=
-    "https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href=
-    "https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href=
-    "https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
-  </footer>
-</body>
+
+
+      <section id="decisions">
+        <h2>
+          Decision Policy
+        </h2>
+        <p>
+          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 3.3</a>). Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+        <p>
+           However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
+        </p>
+        <p>
+          To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
+
+          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from <span id='cfc'><i class="todo">[pick a duration within:] one week to 10 working days</i></span>, depending on the chair's evaluation of the group consensus on the issue.
+
+          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the <i class="todo">(Working|Interest)</i> Group.
+        </p>
+        <p>
+          All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
+        </p>
+        <p>
+          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 3.4, Votes)</a> and includes no voting procedures beyond what the Process Document requires.
+        </p>
+      </section>
+
+
+
+      <section id="patentpolicy">
+      <p><i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i></p>
+
+        <h2>
+          Patent Policy
+        </h2>
+        <p>
+          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
+
+          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/[shortname]/ipr">licensing information</a>.
+        </p>
+
+        <h2>Patent Disclosures </h2>
+        <p>The Interest Group provides an opportunity to
+          share perspectives on the topic addressed by this charter. W3C reminds
+          Interest Group participants of their obligation to comply with patent
+          disclosure obligations as set out in <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">Section
+            6</a> of the W3C Patent Policy. While the Interest Group does not
+          produce Recommendation-track documents, when Interest Group
+          participants review Recommendation-track specifications from Working
+          Groups, the patent disclosure obligations do apply. For more information about disclosure obligations for this group,
+          please see the <a href="https://www.w3.org/groups/ig/[shortname]/ipr">licensing information</a>.</p>
+      </section>
+
+
+
+      <section id="licensing">
+        <h2>Licensing</h2>
+        <p>This <i class="todo">(Working|Interest)</i> Group will use the <i class="todo">[pick a license, one of:]</i>  <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> | <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+      </section>
+
+
+
+      <section id="about">
+        <h2>
+          About this Charter
+        </h2>
+        <p>
+          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#WG-and-IG">section 5.2</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+        </p>
+
+        <section id="history">
+          <h3>
+            Charter History
+          </h3>
+          <p class="issue"><b>Note:</b>Display this table and update it when appropriate. Requirements for charter extension history are documented in the <a href="https://www.w3.org/Guide/process/charter.html#extension">Charter Guidebook (section 4)</a>.</p>
+
+          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 5.2.3)</a>:</p>
+
+          <table class="history">
+            <tbody>
+              <tr>
+                <th>
+                  Charter Period
+                </th>
+                <th>
+                  Start Date
+                </th>
+                <th>
+                  End Date
+                </th>
+                <th>
+                  Changes
+                </th>
+              </tr>
+              <tr>
+                <th>
+                  <a class="todo" href="">Initial Charter</a>
+                </th>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">none</i>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <a class="todo" href="">Charter Extension</a>
+                </th>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">none</i>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <a class="todo" href="">Rechartered</a>
+                </th>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <p class="todo">[description of change to charter, with link to new deliverable item in charter] <b>Note:</b> use the class <code>new</code> for all new deliverables, for ease of recognition.</p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section id="changelog">
+          <h3>Change log</h3>
+
+          <!-- Use this section for changes _after_ the charter was approved by the Director. -->
+          <p>Changes to this document are documented in this section.</p>
+          <!--
+          <dl id='changes'>
+            <dt>YYYY-MM-DD</dt>
+            <dd>[changes]]</dd>
+          </dl>
+          -->
+        </section>
+      </section>
+    </main>
+
+    <hr>
+
+    <footer>
+      <address>
+        <i class="todo"><a href="mailto:">[team contact name]</a></i>
+      </address>
+
+      <p class="copyright">
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
+        <i class="todo">[yyyy]</i>
+        <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (
+        <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="https://www.keio.ac.jp/">Keio</a>,
+        <a href="https://ev.buaa.edu.cn/">Beihang</a>
+        ), All Rights Reserved.
+
+        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
+      </p>
+      <hr>
+      <p><span class='todo'><a href="https://github.com/w3c/charter-drafts">Yes, it's on GitHub!</a>.</span></p>
+    </footer>
+
+  </body>
 </html>


### PR DESCRIPTION
@nigelmegitt @gkatsev , I've aligned with current charter template from 2019 charter.

In addition to yellow highlighted items, I've left some html comment in the file.
Largely updated points (which need some works):

- list of normative specifications
- expected timeline
- W3C group list for coordination (HRs are now omitted, except for special case)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/charter-timed-text/pull/65.html" title="Last updated on Oct 4, 2021, 2:58 PM UTC (0420b81)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/charter-timed-text/65/f367009...himorin:0420b81.html" title="Last updated on Oct 4, 2021, 2:58 PM UTC (0420b81)">Diff</a>