### PR TITLE
fixed editorial comments, and added todo for further discussion points

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,6 +366,13 @@
             requirements and potential solutions to ensure that the Web will function well with TV.</dd>
   
             <dt>
+              <a href="https://www.w3.org/media-wg/">Media Working Group</a>
+            </dt>
+            <dd>
+              The work of the Working Group coordinates with this group on client-side media processing.
+            </dd>
+
+            <dt>
               <a href="https://www.w3.org/community/texttracks/">Web Media Text Tracks Community Group</a>
             </dt>
   

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
               Team Contacts
             </th>
             <td>
-              <a href="mailto:atsushi@w3.org">Atsushi Shimono</a> <i>(0.2 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
+              <a href="mailto:atsushi@w3.org">Atsushi Shimono</a> <i>(0.15 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
             </td>
           </tr>
           <tr>
@@ -243,7 +243,7 @@
       <a href="#advancement">§3.1</a> to demonstrate adequate
       <a href="https://www.w3.org/Consortium/Process/#implementation-experience">implementation experience</a>.</p>
 
-    <p><span class="todo">extend all itemized lines?</span>Each Recommendation-track Technical Report:</p>
+    <p>Each Recommendation-track Technical Report:</p>
 
     <ul>
       <li>SHOULD address the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media Accessibility User Requirements</a></li>
@@ -350,12 +350,6 @@
             dynamic applications. It includes media elements to present video, audio and video text tracks and their
             associated APIs.</dd>
   
-            <dt>
-              <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>
-            </dt>
-  
-            <dd><span class="todo">remove this?</span>
-            </dd>
           </dl>
   
           <p>Invitation for review SHALL be issued during each major Recommendation-track document transition, including

--- a/index.html
+++ b/index.html
@@ -184,18 +184,6 @@
       </p>
     </dd>
 
-    <dt id="webvtt" class="spec"><span class="todo">This is listed in previouysly published normative specifications</span>
-      <a href="https://www.w3.org/TR/webvtt1/">WebVTT: The Web Video Text Tracks Format</a>
-    </dt>
-
-    <dd>
-      <p>This specification defines WebVTT, the Web Video Text Tracks format. Its main use is for marking up
-      external text track resources in connection with the HTML &lt;track&gt; element. WebVTT files provide
-      captions or subtitles for video content, and also text video descriptions <a href=
-      "http://www.w3.org/TR/media-accessibility-reqs/">[MAUR]</a>, chapters for content navigation,
-      and more generally any form of metadata that is time-aligned with audio or video content.</p>
-    </dd>
-
   </dl>
 
   <p>The Working Group MAY develop additional Recommendation-track specifications.</p>

--- a/index.html
+++ b/index.html
@@ -183,7 +183,27 @@
         any directives for rendering that text into audio.
       </p>
     </dd>
+  </dl>
 
+  <h3>New Normative Specifications Continuously Under Development</h3>
+  <p>The Working Group intends to develop the following new W3C normative specifications:</p>
+  <dl>
+    <dt id="webvtt" class="spec">
+      <a href="https://www.w3.org/TR/webvtt1/">WebVTT: The Web Video Text Tracks Format</a>
+    </dt>
+
+    <dd>
+      <p>This specification defines WebVTT, the Web Video Text Tracks format. Its main use is for marking up
+      external text track resources in connection with the HTML &lt;track&gt; element. WebVTT files provide
+      captions or subtitles for video content, and also text video descriptions <a href=
+      "http://www.w3.org/TR/media-accessibility-reqs/">[MAUR]</a>, chapters for content navigation,
+      and more generally any form of metadata that is time-aligned with audio or video content.</p>
+      <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webvtt1/">Candidate Recommendation</a></p>
+      <p><b>Adopted Working Draft:</b> <a href="https://www.w3.org/TR/2019/CR-webvtt1-20190404/">WebVTT: The Web Video Text Tracks Format</a> (4 April 2019)</p>
+      <p><b>Produced under Working Group Charter:</b> <a href="https://www.w3.org/2018/05/timed-text-charter.html">2018-2020 charter period of the Timed Text Working Group</a></p>
+      <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2019/CR-webvtt1-20190404/">https://www.w3.org/TR/2019/CR-webvtt1-20190404/</a><br>
+      associated <a href="https://www.w3.org/mid/cfe-6964-e72ae545706a44a8b42f44f11fc0b2e98a4feca3@w3.org">Call for Exclusion</a> on 2019-04-04 ended on 2019-06-03</p>
+    </dd>
   </dl>
 
   <p>The Working Group MAY develop additional Recommendation-track specifications.</p>
@@ -234,14 +254,13 @@
     <p>Each Recommendation-track Technical Report:</p>
 
     <ul>
+      <li>SHOULD contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.</li>
+      <li>SHOULD have an associated testing plan, starting from the earliest drafts.</li>
+      <li>SHOULD contain a section on accessibility that describes the benefits and impacts, including ways that features defined in the Technical Report can be used to address them, and recommendations for maximising accessibility in implementations.</li>
       <li>SHOULD address the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media Accessibility User Requirements</a></li>
       <li>SHOULD contain a section discussing interoperability with previous versions, if any, of the Technical Report, and other relevant specifications.</li>
     </ul>
     <p>To promote interoperability, all normative changes made to Technical Reports SHOULD have associated <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
-    <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
-    <p>There should be testing plans for each specification, starting from the earliest drafts. To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
-    <p>Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
-		recommendations for maximising accessibility in implementations.</p>
     <section id="advancement">
     <h3>Requirements for advancing the maturity level of features</h3>
     <p>Within the requirements of the Process each new normative feature

--- a/index.html
+++ b/index.html
@@ -204,6 +204,36 @@
       <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2019/CR-webvtt1-20190404/">https://www.w3.org/TR/2019/CR-webvtt1-20190404/</a><br>
       associated <a href="https://www.w3.org/mid/cfe-6964-e72ae545706a44a8b42f44f11fc0b2e98a4feca3@w3.org">Call for Exclusion</a> on 2019-04-04 ended on 2019-06-03</p>
     </dd>
+
+    <dt id="imsc-hrm" class="spec">
+      <a href="https://www.w3.org/TR/imsc-hrm/">IMSC Hypothetical Render Model</a>
+    </dt>
+    <dd>
+      <p>This specification specifies an Hypothetical Render Model (HRM) that constrains 
+        the complexity of an <a href="https://www.w3.org/TR/imsc-hrm/#dfn-imsc-document-instance">IMSC Document Instance</a>.</p>
+      <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/imsc-hrm/">Working Draft</a></p>
+      <p><b>Adopted Working Draft:</b> <a href="https://www.w3.org/TR/2022/WD-imsc-hrm-20220106/">IMSC Hypothetical Render Model</a> (6 January 2022)</p>
+      <p><b>Produced under Working Group Charter:</b> <a href="https://www.w3.org/2020/12/timed-text-wg-charter.html">2020-2021 charter period of the Timed Text Working group</a></p>
+      <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2021/WD-imsc-hrm-20211109/">https://www.w3.org/TR/2021/WD-imsc-hrm-20211109/</a><br>
+        associated <a href="https://www.w3.org/mid/cfe-8827-056dc58f61ddaaa4e706e76df899cf92b5e3472e@w3.org"> Call for Exclusion</a> on 2021-11-09 will end on 2022-04-08</p>
+    </dd>
+
+    <dt id="ttml2-2" class="spec">
+      <a href="https://www.w3.org/TR/2021/CR-ttml2-20210309/">Timed Text Markup Language 2 (TTML2) (2nd Edition)</a>
+    </dt>
+    <dd>
+      <p>This document specifies the Second Edition of the Timed Text Markup Language (TTML), Version 2, 
+        also known as TTML2 (2e), in terms of a vocabulary and semantics thereof.<br>
+        The Timed Text Markup Language is a content type that represents timed text media 
+        for the purpose of interchange among authoring systems. 
+        Timed text is textual information that is intrinsically or extrinsically associated 
+        with timing information.</p>
+      <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/2021/CR-ttml2-20210309/">Candidate Recommendation</a></p>
+      <p><b>Adopted Working Draft:</b> <a href="https://www.w3.org/TR/2021/CR-ttml2-20210309/">Timed Text Markup Language 2 (TTML2) (2nd Edition)</a> (9 March 2021)</p>
+      <p><b>Produced under Working Group Charter:</b> <a href="https://www.w3.org/2020/12/timed-text-wg-charter.html">2020-2021 charter period of the Timed Text Working group</a></p>
+      <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2021/CR-ttml2-20210309/">https://www.w3.org/TR/2021/CR-ttml2-20210309/</a><br>
+        associated <a href="https://www.w3.org/mid/cfe-7902-2bd4311cd121005bd8aac846f56a43bc4bb22b50@w3.org">Call for Exclusion</a> on 2021-03-09 ended on 2021-05-08</p>
+    </dd>
   </dl>
 
   <p>The Working Group MAY develop additional Recommendation-track specifications.</p>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,6 @@
           <li><a href="#communication">Communication</a></li>
           <li><a href="#decisions">Decision Policy</a></li>
           <li><a href="#patentpolicy">Patent Policy</a></li>
-          <li><a href="#patentpolicy">Patent Disclosures</a></li>
           <li><a href="#licensing">Licensing</a></li>
           <li><a href="#about">About this Charter</a></li>
         </ul>
@@ -185,7 +184,7 @@
       </p>
     </dd>
 
-    <dt id="webvtt" class="spec">
+    <dt id="webvtt" class="spec"><span class="todo">This is listed in previouysly published normative specifications</span>
       <a href="https://www.w3.org/TR/webvtt1/">WebVTT: The Web Video Text Tracks Format</a>
     </dt>
 
@@ -244,12 +243,9 @@
       <a href="#advancement">§3.1</a> to demonstrate adequate
       <a href="https://www.w3.org/Consortium/Process/#implementation-experience">implementation experience</a>.</p>
 
-    <p>Each Recommendation-track Technical Report:</p>
+    <p><span class="todo">extend all itemized lines?</span>Each Recommendation-track Technical Report:</p>
 
     <ul>
-      <li>SHOULD contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.</li>
-      <li>SHOULD have an associated testing plan, starting from the earliest drafts.</li>
-      <li>SHOULD contain a section on accessibility that describes the benefits and impacts, including ways that features defined in the Technical Report can be used to address them, and recommendations for maximising accessibility in implementations.</li>
       <li>SHOULD address the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media Accessibility User Requirements</a></li>
       <li>SHOULD contain a section discussing interoperability with previous versions, if any, of the Technical Report, and other relevant specifications.</li>
     </ul>
@@ -346,7 +342,7 @@
             <dd>This group is to help bring high-performance Virtual Reality and Augmented Reality to the open Web.</dd>
   
             <dt>
-              <a href="https://www.w3.org/WebPlatform/WG/">Web Platform Working Group</a>
+              <a href="https://www.w3.org/groups/wg/htmlwg">HTML Working Group</a>
             </dt>
   
             <dd>The HTML specification is intended to provide a semantic-level markup language and associated
@@ -358,7 +354,7 @@
               <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>
             </dt>
   
-            <dd>
+            <dd><span class="todo">remove this?</span>
             </dd>
           </dl>
   


### PR DESCRIPTION
fixed editorial comments.
also, I feel copied items from current charter in success criteria are better to be de-itemized. how about?

also added todo label for pointed parts, 
- Groups coordination: 
  - Web Platform to HTML (fixed)
  - listing TAG is intention?
  - consider to add Media WG, WebRTC WG, Immersive Captions CG?
- WebVTT is listed in wiki page as previously (in-flight) published spec


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/charter-timed-text/pull/69.html" title="Last updated on Feb 7, 2022, 6:06 AM UTC (e0e3d84)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/charter-timed-text/69/740c336...himorin:e0e3d84.html" title="Last updated on Feb 7, 2022, 6:06 AM UTC (e0e3d84)">Diff</a>