### PR TITLE
replaced AudioVideo/TT/ to groups/timed-text

### DIFF
--- a/index.html
+++ b/index.html
@@ -498,7 +498,7 @@
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/groups/AudioVideo/TT/">Timed Text Working Group home page</a>.
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/AudioVideo/TT/">Timed Text Working Group home page</a>.
         </p>
         <p>
           Most <a href="https://www.w3.org/groups/wg/timed-text">Timed Text Working Group</a> teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
       </p>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/AudioVideo/TT/">Timed Text
+      <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/groups/wg/timed-text">Timed Text
         Working Group</a> is to develop W3C Recommendations for the representation of timed text in media, including
         developing and maintaining new versions of the <a href="https://www.w3.org/TR/ttml/">Timed Text Markup Language</a> (TTML) and <a href="https://www.w3.org/TR/webvtt/">WebVTT</a> (Web Video Text Tracks)
         based on implementation experience and interoperability feedback, and the creation of semantic mappings between
@@ -498,10 +498,10 @@
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/AudioVideo/TT/">Timed Text Working Group home page</a>.
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/groups/wg/timed-text">Timed Text Working Group home page</a>.
         </p>
         <p>
-          Most <a href="https://www.w3.org/AudioVideo/TT/">Timed Text Working Group</a> teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+          Most <a href="https://www.w3.org/groups/wg/timed-text">Timed Text Working Group</a> teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>This Working Group primarily conducts its technical work on the public mailing list public-tt@w3.org (<a href=
           "http://lists.w3.org/Archives/Public/public-tt/">archive</a>) or <a id="public-github" href=

--- a/index.html
+++ b/index.html
@@ -498,7 +498,7 @@
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/groups/wg/timed-text">Timed Text Working Group home page</a>.
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/groups/AudioVideo/TT/">Timed Text Working Group home page</a>.
         </p>
         <p>
           Most <a href="https://www.w3.org/groups/wg/timed-text">Timed Text Working Group</a> teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.


### PR DESCRIPTION
per request from W3C Communications, to point new group page entirety as group home.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/charter-timed-text/pull/76.html" title="Last updated on Mar 10, 2022, 7:08 PM UTC (1d0ce69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/charter-timed-text/76/4b2e5f1...himorin:1d0ce69.html" title="Last updated on Mar 10, 2022, 7:08 PM UTC (1d0ce69)">Diff</a>