### PR TITLE
Reintroduce the 'at least two independent implementations' SHOULD from the previous version of the charter.

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,6 +296,13 @@
     <p>Within the requirements of the Process each new normative feature
     will be considered as ready to advance to a higher maturity level if
     its implementability has been demonstrated.</p>
+    <p>In order to advance to <a
+    href="https://www.w3.org/Consortium/Process/#RecsPR"
+    title="Proposed Recommendation">Proposed Recommendation</a>, each
+    Recommendation-track Technical Report SHOULD have <a
+    href="https://www.w3.org/Consortium/Process/#implementation-experience">at
+    least two independent implementations</a> of each feature defined in
+    the Technical Report.</p>
     <p>When considering suitability to advance any feature beyond
     Candidate Recommendation, at least two independent factors of verification
     MUST be demonstrated, which may come from any of:</p>


### PR DESCRIPTION
@dwsinger, @gkatsev, @nigelmegitt, and I had a call earlier today to talk about possible ways to resolve Apple's charter FO. One possibility is a "belt-and-suspenders" approach where we have the old charter language as well as the new charter language re: implementations.

This is an inelegant first pass at this. I made no attempt to fiddle with the surrounding wording or to make the resulting frankensteinian text cohere. This PR merely reintroduces the old text as a starting point for conversation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hober/charter-timed-text/pull/81.html" title="Last updated on Sep 23, 2022, 9:26 PM UTC (116dc6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/charter-timed-text/81/229fd25...hober:116dc6c.html" title="Last updated on Sep 23, 2022, 9:26 PM UTC (116dc6c)">Diff</a>